### PR TITLE
chore: clippy, fmt, and crate readme updates

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,25 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Publish to crates.io
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          check-repo: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,10 @@ jobs:
           bash update_libchdb.sh --local
           sudo mv libchdb.so /usr/lib/libchdb.so
           sudo ldconfig
+    - name: Check formatting
+      run: cargo fmt --check
+    - name: Check clippy
+      run: cargo clippy --all-targets --all-features -- --deny warnings
     - name: Build
       run: cargo build --verbose
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chdb-rust"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 authors = ["Auxten"]
 description = "chDB FFI bindings for Rust(Experimental)"

--- a/README.md
+++ b/README.md
@@ -1,53 +1,137 @@
 <img src="https://avatars.githubusercontent.com/u/132536224" width=130 />
 
 [![Rust](https://github.com/chdb-io/chdb-rust/actions/workflows/rust.yml/badge.svg)](https://github.com/chdb-io/chdb-rust/actions/workflows/rust.yml)
+[![Crates.io](https://img.shields.io/crates/v/chdb-rust.svg)](https://crates.io/crates/chdb-rust)
+[![docs.rs](https://docs.rs/chdb-rust/badge.svg)](https://docs.rs/chdb-rust)
 
 # chdb-rust <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Rust_programming_language_black_logo.svg/1024px-Rust_programming_language_black_logo.svg.png" height=20 />
 
-Experimental [chDB](https://github.com/chdb-io/chdb) FFI bindings for Rust
+Experimental [chDB](https://github.com/chdb-io/chdb) FFI bindings for Rust.
+
+## Documentation
+
+**[Full API Documentation](https://docs.rs/crate/chdb-rust/latest)** - Complete Rust API reference on docs.rs
 
 ## Status
 
-- Experimental, unstable, subject to changes
-- Automatically downloads and manages [`libchdb`](https://github.com/chdb-io/chdb) dependencies during build
+**Experimental** - This library is currently experimental, unstable, and subject to changes.
 
-## Usage
+The library automatically downloads and manages [`libchdb`](https://github.com/chdb-io/chdb) dependencies during the build process.
 
-The library automatically downloads the required `libchdb` binary during the build process.
+## Quick Start
 
-### Supported platforms:
-- Linux x86_64
-- Linux aarch64  
-- macOS x86_64
-- macOS arm64 (Apple Silicon)
+Add `chdb-rust` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+chdb-rust = "1.1.0"
+```
+
+The library will automatically download the required `libchdb` binary during the build process.
+
+## Supported Platforms
+
+- **Linux**: x86_64, aarch64
+- **macOS**: x86_64, arm64 (Apple Silicon)
+
+## Building
+
+### Standard Build
+
+```bash
+cargo build
+```
+
+### Verbose Build (for debugging)
+
+```bash
+RUST_BACKTRACE=full cargo build --verbose
+```
 
 ### Manual Installation (Optional)
 
-If you prefer to install `libchdb` manually, you can:
+If you prefer to install `libchdb` manually instead of automatic download:
 
-Install it system-wide:
+**System-wide installation:**
 ```bash
 ./update_libchdb.sh --global
 ```
 
-Or use it in a local directory:
+**Local directory installation:**
 ```bash
 ./update_libchdb.sh --local
 ```
 
-### Build
+## Testing
+
+Run the test suite:
 
 ```bash
-RUST_BACKTRACE=full cargo build --verbose
-
+cargo test -- --test-threads=1
 ```
 
-### Run tests
+## Examples
 
-`cargo test`
+- **Runnable examples**: See the [examples/](examples/) directory
+  ```bash
+  cargo run --example <name>
+  ```
+- **Detailed documentation**: See [docs/examples.md](docs/examples.md) for comprehensive examples and explanations
+- **Test examples**: See [tests/](tests/) directory for additional usage examples
 
-### Examples
+## Contributing
 
-- **Runnable examples**: See the `examples/` directory. Run them with `cargo run --example <name>`
-- **Documentation**: See `docs/examples.md` for detailed examples and explanations
-- **Tests**: See `tests/` directory for test examples
+We welcome contributions! Here's how you can help:
+
+### Getting Started
+
+1. **Fork the repository** and clone your fork
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/chdb-rust.git
+   cd chdb-rust
+   ```
+
+2. **Create a branch** for your changes
+   ```bash
+   git checkout -b feature/your-feature-name
+   # or
+   git checkout -b fix/your-bug-fix
+   ```
+
+3. **Make your changes** and ensure they work
+   - Run tests: `cargo test`
+   - Check formatting: `cargo fmt --check`
+   - Run clippy: `cargo clippy`
+
+4. **Commit your changes** with clear, descriptive commit messages
+   ```bash
+   git commit -m "Add feature: description of what you did"
+   ```
+
+5. **Push to your fork** and open a Pull Request
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+### Development Guidelines
+
+- **Code Style**: Follow Rust conventions and run `cargo fmt` before committing
+- **Testing**: Add tests for new features and ensure all existing tests pass
+- **Documentation**: Update relevant documentation for user-facing changes
+- **Commit Messages**: Write clear, descriptive commit messages
+- **Pull Requests**: 
+  - Provide a clear description of your changes
+  - Reference any related issues
+  - Ensure CI checks pass
+
+### Reporting Issues
+
+Found a bug or have a feature request? Please open an issue on GitHub with:
+- A clear description of the problem or feature
+- Steps to reproduce (for bugs)
+- Expected vs actual behavior
+- Your environment (OS, Rust version, etc.)
+
+### Questions?
+
+Feel free to open a discussion or issue if you have questions about contributing!

--- a/examples/01_stateless_queries.rs
+++ b/examples/01_stateless_queries.rs
@@ -1,37 +1,36 @@
+use chdb_rust::arg::Arg;
 /// Example: Stateless Queries
-/// 
+///
 /// This example demonstrates how to execute one-off queries that don't require
 /// persistent storage using the `execute` function.
-
 use chdb_rust::execute;
-use chdb_rust::arg::Arg;
 use chdb_rust::format::OutputFormat;
 
 fn main() -> Result<(), chdb_rust::error::Error> {
     println!("=== Stateless Query Examples ===\n");
-    
+
     // Simple query with default format (TabSeparated)
     println!("1. Simple query with default format:");
     let result = execute("SELECT 1 + 1 AS sum", None)?;
     println!("Result: {}", result.data_utf8_lossy());
     println!();
-    
+
     // Query with JSON output format
     println!("2. Query with JSON output format:");
     let result = execute(
         "SELECT 'Hello' AS greeting, 42 AS answer",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     )?;
     println!("JSON Result: {}", result.data_utf8_lossy());
     println!();
-    
+
     // More complex query
     println!("3. Complex query with calculations:");
     let result = execute(
         "SELECT number, number * 2 AS doubled, number * number AS squared FROM numbers(5)",
-        Some(&[Arg::OutputFormat(OutputFormat::Pretty)])
+        Some(&[Arg::OutputFormat(OutputFormat::Pretty)]),
     )?;
     println!("{}", result.data_utf8_lossy());
-    
+
     Ok(())
 }

--- a/examples/02_stateful_sessions.rs
+++ b/examples/02_stateful_sessions.rs
@@ -1,64 +1,59 @@
-/// Example: Stateful Sessions
-/// 
-/// This example demonstrates how to use sessions for queries that need
-/// persistent storage (creating tables, inserting data, etc.).
-
-use chdb_rust::session::SessionBuilder;
 use chdb_rust::arg::Arg;
 use chdb_rust::format::OutputFormat;
+/// Example: Stateful Sessions
+///
+/// This example demonstrates how to use sessions for queries that need
+/// persistent storage (creating tables, inserting data, etc.).
+use chdb_rust::session::SessionBuilder;
 
 fn main() -> Result<(), chdb_rust::error::Error> {
     println!("=== Stateful Session Examples ===\n");
-    
+
     // Create a session with a temporary directory
     let tmp_dir = std::env::temp_dir().join("chdb-example");
     let session = SessionBuilder::new()
         .with_data_path(tmp_dir)
         .with_auto_cleanup(true) // Automatically delete data on drop
         .build()?;
-    
+
     println!("1. Creating database and table...");
-    
+
     // Create a database
-    session.execute(
-        "CREATE DATABASE mydb; USE mydb",
-        Some(&[Arg::MultiQuery])
-    )?;
-    
+    session.execute("CREATE DATABASE mydb; USE mydb", Some(&[Arg::MultiQuery]))?;
+
     // Create a table
     session.execute(
         "CREATE TABLE users (id UInt64, name String, age UInt8) \
          ENGINE = MergeTree() ORDER BY id",
-        None
+        None,
     )?;
-    
+
     println!("2. Inserting data...");
-    
+
     // Insert data
     session.execute(
         "INSERT INTO users (id, name, age) VALUES (1, 'Alice', 30), (2, 'Bob', 25)",
-        None
+        None,
     )?;
-    
+
     println!("3. Querying data...\n");
-    
+
     // Query data
     let result = session.execute(
         "SELECT * FROM users",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     )?;
-    
+
     println!("Users:");
     println!("{}", result.data_utf8_lossy());
-    
+
     // Query with aggregation
     println!("4. Aggregated query:");
     let result = session.execute(
         "SELECT COUNT(*) AS total_users, AVG(age) AS avg_age FROM users",
-        Some(&[Arg::OutputFormat(OutputFormat::Pretty)])
+        Some(&[Arg::OutputFormat(OutputFormat::Pretty)]),
     )?;
     println!("{}", result.data_utf8_lossy());
-    
+
     Ok(())
 }
-

--- a/examples/03_query_results.rs
+++ b/examples/03_query_results.rs
@@ -1,52 +1,50 @@
+use chdb_rust::arg::Arg;
 /// Example: Working with Query Results
-/// 
+///
 /// This example demonstrates the various methods available on QueryResult
 /// to access query results and statistics.
-
 use chdb_rust::execute;
-use chdb_rust::arg::Arg;
 use chdb_rust::format::OutputFormat;
 
 fn main() -> Result<(), chdb_rust::error::Error> {
     println!("=== Query Results Examples ===\n");
-    
+
     let result = execute(
         "SELECT number, number * 2 AS doubled FROM numbers(5)",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     )?;
-    
+
     println!("1. Getting result as UTF-8 string:");
     // Get result as UTF-8 string (returns error if invalid UTF-8)
     match result.data_utf8() {
-        Ok(data) => println!("UTF-8: {}", data),
-        Err(e) => eprintln!("Error: {}", e),
+        Ok(data) => println!("UTF-8: {data}"),
+        Err(e) => eprintln!("Error: {e}"),
     }
     println!();
-    
+
     // Note: We need to execute again because data_utf8() consumes the result
     let result = execute(
         "SELECT number, number * 2 AS doubled FROM numbers(5)",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     )?;
-    
+
     println!("2. Getting result as UTF-8 string (lossy conversion):");
     // Get result as UTF-8 string (lossy conversion for invalid UTF-8)
     println!("Lossy UTF-8: {}", result.data_utf8_lossy());
     println!();
-    
+
     println!("3. Getting raw bytes:");
     // Get raw bytes
     let bytes = result.data_ref();
     println!("Bytes length: {}", bytes.len());
     println!("First 50 bytes: {:?}", &bytes[..bytes.len().min(50)]);
     println!();
-    
+
     println!("4. Query statistics:");
     // Get query statistics
     println!("Rows read: {}", result.rows_read());
     println!("Bytes read: {}", result.bytes_read());
     println!("Elapsed time: {:?}", result.elapsed());
-    
+
     Ok(())
 }
-

--- a/examples/04_output_formats.rs
+++ b/examples/04_output_formats.rs
@@ -1,60 +1,46 @@
-/// Example: Output Formats
-/// 
-/// This example demonstrates the various output formats supported by chdb-rust.
-
-use chdb_rust::execute;
 use chdb_rust::arg::Arg;
+/// Example: Output Formats
+///
+/// This example demonstrates the various output formats supported by chdb-rust.
+use chdb_rust::execute;
 use chdb_rust::format::OutputFormat;
 
 fn main() -> Result<(), chdb_rust::error::Error> {
     println!("=== Output Formats Examples ===\n");
-    
+
     let query = "SELECT 1 AS a, 'test' AS b, 3.14 AS pi";
-    
+
     println!("1. JSONEachRow - one JSON object per line:");
-    let result = execute(
-        query,
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
-    )?;
+    let result = execute(query, Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]))?;
     println!("{}", result.data_utf8_lossy());
     println!();
-    
+
     println!("2. CSV with column names:");
     let result = execute(
         query,
-        Some(&[Arg::OutputFormat(OutputFormat::CSVWithNames)])
+        Some(&[Arg::OutputFormat(OutputFormat::CSVWithNames)]),
     )?;
     println!("{}", result.data_utf8_lossy());
     println!();
-    
+
     println!("3. Pretty format (human-readable table):");
-    let result = execute(
-        query,
-        Some(&[Arg::OutputFormat(OutputFormat::Pretty)])
-    )?;
+    let result = execute(query, Some(&[Arg::OutputFormat(OutputFormat::Pretty)]))?;
     println!("{}", result.data_utf8_lossy());
     println!();
-    
+
     println!("4. TabSeparated (default):");
     let result = execute(query, None)?;
     println!("{}", result.data_utf8_lossy());
     println!();
-    
+
     println!("5. JSON (single JSON object):");
-    let result = execute(
-        query,
-        Some(&[Arg::OutputFormat(OutputFormat::JSON)])
-    )?;
+    let result = execute(query, Some(&[Arg::OutputFormat(OutputFormat::JSON)]))?;
     println!("{}", result.data_utf8_lossy());
     println!();
-    
+
     println!("6. Markdown table:");
-    let result = execute(
-        query,
-        Some(&[Arg::OutputFormat(OutputFormat::Markdown)])
-    )?;
+    let result = execute(query, Some(&[Arg::OutputFormat(OutputFormat::Markdown)]))?;
     println!("{}", result.data_utf8_lossy());
-    
+
     Ok(())
 }
-

--- a/examples/05_reading_from_files.rs
+++ b/examples/05_reading_from_files.rs
@@ -1,56 +1,54 @@
+use chdb_rust::arg::Arg;
 /// Example: Reading from Files
-/// 
+///
 /// This example demonstrates how to query data directly from files using
 /// ClickHouse's `file()` function.
-
 use chdb_rust::execute;
-use chdb_rust::arg::Arg;
 use chdb_rust::format::{InputFormat, OutputFormat};
 
 fn main() -> Result<(), chdb_rust::error::Error> {
     println!("=== Reading from Files Examples ===\n");
-    
+
     // Note: This example assumes you have a CSV file at tests/logs.csv
     // You can modify the path to point to your own file
-    
+
     println!("1. Reading from CSV file:");
     let query = format!(
         "SELECT * FROM file('tests/logs.csv', {})",
         InputFormat::CSV.as_str()
     );
-    
+
     match execute(
         &query,
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     ) {
         Ok(result) => {
             println!("CSV data:\n{}", result.data_utf8_lossy());
         }
         Err(e) => {
-            println!("Note: Could not read tests/logs.csv: {}", e);
+            println!("Note: Could not read tests/logs.csv: {e}");
             println!("This is expected if the file doesn't exist.");
             println!("You can create a CSV file and update the path in this example.");
         }
     }
     println!();
-    
+
     // Example with inline CSV data using VALUES
     println!("2. Using inline data (simulating file read):");
     let result = execute(
         "SELECT * FROM (SELECT 1 AS id, 'test' AS msg) FORMAT JSONEachRow",
-        Some(&[Arg::OutputFormat(OutputFormat::Pretty)])
+        Some(&[Arg::OutputFormat(OutputFormat::Pretty)]),
     )?;
     println!("{}", result.data_utf8_lossy());
     println!();
-    
+
     println!("3. Reading from JSON file (example query):");
     let query = format!(
         "SELECT * FROM file('data.json', {}) LIMIT 10",
         InputFormat::JSONEachRow.as_str()
     );
-    println!("Query would be: {}", query);
+    println!("Query would be: {query}");
     println!("(Update the path to point to your JSON file)");
-    
+
     Ok(())
 }
-

--- a/examples/06_error_handling.rs
+++ b/examples/06_error_handling.rs
@@ -1,70 +1,69 @@
+use chdb_rust::arg::Arg;
+use chdb_rust::error::Error;
 /// Example: Error Handling
-/// 
+///
 /// This example demonstrates how to properly handle errors when working
 /// with chdb-rust.
-
 use chdb_rust::execute;
-use chdb_rust::arg::Arg;
 use chdb_rust::format::OutputFormat;
-use chdb_rust::error::Error;
 
 fn main() {
     println!("=== Error Handling Examples ===\n");
-    
+
     println!("1. Handling query errors:");
     match execute(
         "SELECT * FROM nonexistent_table",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     ) {
         Ok(result) => {
             println!("Success: {}", result.data_utf8_lossy());
         }
         Err(Error::QueryError(msg)) => {
-            println!("Query error caught: {}", msg);
+            println!("Query error caught: {msg}");
         }
         Err(Error::ConnectionFailed) => {
             eprintln!("Failed to connect to database");
         }
         Err(e) => {
-            eprintln!("Other error: {}", e);
+            eprintln!("Other error: {e}");
         }
     }
     println!();
-    
+
     println!("2. Handling syntax errors:");
     match execute(
         "SELECT * FROM WHERE invalid syntax",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     ) {
         Ok(result) => {
             println!("Unexpected success: {}", result.data_utf8_lossy());
         }
         Err(Error::QueryError(msg)) => {
-            println!("Syntax error caught: {}", msg);
+            println!("Syntax error caught: {msg}");
         }
         Err(e) => {
-            println!("Error: {}", e);
+            println!("Error: {e}");
         }
     }
     println!();
-    
+
     println!("3. Successful query:");
     match execute(
         "SELECT 1 + 1 AS result",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     ) {
         Ok(result) => {
             println!("Success: {}", result.data_utf8_lossy());
         }
         Err(e) => {
-            eprintln!("Unexpected error: {}", e);
+            eprintln!("Unexpected error: {e}");
         }
     }
     println!();
-    
+
     println!("4. Using ? operator in a function:");
     if let Err(e) = demonstrate_error_propagation() {
-        println!("Error propagated: {}", e);
+        println!("Error propagated: {e}");
     }
 }
 
@@ -72,10 +71,9 @@ fn demonstrate_error_propagation() -> Result<(), Error> {
     // This function demonstrates how errors can be propagated using ?
     let result = execute(
         "SELECT number FROM numbers(3)",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     )?;
-    
+
     println!("Result from function: {}", result.data_utf8_lossy());
     Ok(())
 }
-

--- a/examples/07_analytics.rs
+++ b/examples/07_analytics.rs
@@ -1,30 +1,29 @@
-/// Example: Building a Simple Analytics Query
-/// 
-/// This is a complete example that demonstrates a typical analytics use case
-/// with event tracking, aggregation, and time-based queries.
-
-use chdb_rust::session::SessionBuilder;
 use chdb_rust::arg::Arg;
 use chdb_rust::format::OutputFormat;
+/// Example: Building a Simple Analytics Query
+///
+/// This is a complete example that demonstrates a typical analytics use case
+/// with event tracking, aggregation, and time-based queries.
+use chdb_rust::session::SessionBuilder;
 
 fn main() -> Result<(), chdb_rust::error::Error> {
     println!("=== Analytics Example ===\n");
-    
+
     // Create session
     let tmp_dir = std::env::temp_dir().join("chdb-analytics");
     let session = SessionBuilder::new()
         .with_data_path(tmp_dir)
         .with_auto_cleanup(true)
         .build()?;
-    
+
     println!("1. Creating database and table...");
-    
+
     // Create database and table
     session.execute(
         "CREATE DATABASE analytics; USE analytics",
-        Some(&[Arg::MultiQuery])
+        Some(&[Arg::MultiQuery]),
     )?;
-    
+
     session.execute(
         "CREATE TABLE events (
             id UInt64,
@@ -32,11 +31,11 @@ fn main() -> Result<(), chdb_rust::error::Error> {
             timestamp DateTime,
             value Float64
         ) ENGINE = MergeTree() ORDER BY timestamp",
-        None
+        None,
     )?;
-    
+
     println!("2. Inserting sample events...");
-    
+
     // Insert sample events
     session.execute(
         "INSERT INTO events VALUES
@@ -50,11 +49,11 @@ fn main() -> Result<(), chdb_rust::error::Error> {
         (8, 'page_view', '2024-01-01 11:00:00', 1.0),
         (9, 'click', '2024-01-01 11:05:00', 3.0),
         (10, 'page_view', '2024-01-01 11:10:00', 1.0)",
-        None
+        None,
     )?;
-    
+
     println!("3. Event statistics by type:\n");
-    
+
     // Aggregate query
     let result = session.execute(
         "SELECT 
@@ -65,14 +64,14 @@ fn main() -> Result<(), chdb_rust::error::Error> {
         FROM events
         GROUP BY event_type
         ORDER BY count DESC",
-        Some(&[Arg::OutputFormat(OutputFormat::Pretty)])
+        Some(&[Arg::OutputFormat(OutputFormat::Pretty)]),
     )?;
-    
+
     println!("{}", result.data_utf8_lossy());
     println!();
-    
+
     println!("4. Hourly event distribution:\n");
-    
+
     // Time-based query
     let result = session.execute(
         "SELECT 
@@ -81,14 +80,14 @@ fn main() -> Result<(), chdb_rust::error::Error> {
         FROM events
         GROUP BY hour
         ORDER BY hour",
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)])
+        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
     )?;
-    
+
     println!("{}", result.data_utf8_lossy());
     println!();
-    
+
     println!("5. Conversion funnel:\n");
-    
+
     // Conversion funnel analysis
     let result = session.execute(
         "SELECT 
@@ -104,11 +103,10 @@ fn main() -> Result<(), chdb_rust::error::Error> {
                 WHEN 'purchase' THEN 3
                 ELSE 4
             END",
-        Some(&[Arg::OutputFormat(OutputFormat::Pretty)])
+        Some(&[Arg::OutputFormat(OutputFormat::Pretty)]),
     )?;
-    
+
     println!("{}", result.data_utf8_lossy());
-    
+
     Ok(())
 }
-

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -61,13 +61,13 @@ impl<'a> Arg<'a> {
     #[allow(dead_code)]
     pub(crate) fn to_cstring(&self) -> Result<CString, Error> {
         Ok(match self {
-            Self::ConfigFilePath(v) => CString::new(format!("--config-file={}", v)),
+            Self::ConfigFilePath(v) => CString::new(format!("--config-file={v}")),
             Self::LogLevel(v) => CString::new(format!("--log-level={}", v.as_str())),
             Self::OutputFormat(v) => CString::new(format!("--output-format={}", v.as_str())),
             Self::MultiQuery => CString::new("-n"),
             Self::Custom(k, v) => match v {
                 None => CString::new(k.as_ref()),
-                Some(v) => CString::new(format!("--{}={}", k, v)),
+                Some(v) => CString::new(format!("--{k}={v}")),
             },
         }?)
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -138,7 +138,7 @@ impl Connection {
     /// Returns [`Error::ConnectionFailed`] if the
     /// connection cannot be established.
     pub fn open_with_path(path: &str) -> Result<Self> {
-        let path_arg = format!("--path={}", path);
+        let path_arg = format!("--path={path}");
         Self::open(&["clickhouse", &path_arg])
     }
 
@@ -181,9 +181,8 @@ impl Connection {
 
         // chdb_query takes chdb_connection (which is *mut chdb_connection_)
         let conn = unsafe { *self.inner };
-        let result_ptr = unsafe {
-            bindings::chdb_query(conn, query_cstr.as_ptr(), format_cstr.as_ptr())
-        };
+        let result_ptr =
+            unsafe { bindings::chdb_query(conn, query_cstr.as_ptr(), format_cstr.as_ptr()) };
 
         if result_ptr.is_null() {
             return Err(Error::NoResult);

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -92,10 +92,7 @@ fn test_output_formats() -> Result<()> {
     let query = "SELECT 1 AS a, 'test' AS b, 3.14 AS pi";
 
     // Test JSONEachRow
-    let result = execute(
-        query,
-        Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]),
-    )?;
+    let result = execute(query, Some(&[Arg::OutputFormat(OutputFormat::JSONEachRow)]))?;
     let json_output = result.data_utf8_lossy();
     assert!(json_output.contains("\"a\":1"));
     assert!(json_output.contains("\"b\":\"test\""));
@@ -112,10 +109,7 @@ fn test_output_formats() -> Result<()> {
     assert!(!csv_output.is_empty());
 
     // Test Pretty format
-    let result = execute(
-        query,
-        Some(&[Arg::OutputFormat(OutputFormat::Pretty)]),
-    )?;
+    let result = execute(query, Some(&[Arg::OutputFormat(OutputFormat::Pretty)]))?;
     let pretty_output = result.data_utf8_lossy();
     assert!(!pretty_output.is_empty());
 
@@ -181,7 +175,6 @@ fn test_query_result_data_methods() -> Result<()> {
     )?;
     let bytes = result.data_ref();
     assert!(!bytes.is_empty());
-    assert!(bytes.len() > 0);
 
     Ok(())
 }
@@ -194,7 +187,10 @@ fn test_multiple_inserts_and_aggregation() -> Result<()> {
         .with_auto_cleanup(true)
         .build()?;
 
-    session.execute("CREATE DATABASE testdb; USE testdb", Some(&[Arg::MultiQuery]))?;
+    session.execute(
+        "CREATE DATABASE testdb; USE testdb",
+        Some(&[Arg::MultiQuery]),
+    )?;
 
     session.execute(
         "CREATE TABLE products (id UInt64, name String, price Float64) \
@@ -243,7 +239,10 @@ fn test_different_data_types() -> Result<()> {
         .with_auto_cleanup(true)
         .build()?;
 
-    session.execute("CREATE DATABASE testdb; USE testdb", Some(&[Arg::MultiQuery]))?;
+    session.execute(
+        "CREATE DATABASE testdb; USE testdb",
+        Some(&[Arg::MultiQuery]),
+    )?;
 
     session.execute(
         "CREATE TABLE types_test (
@@ -289,11 +288,9 @@ fn test_error_handling_table_not_found() {
 
     if let Err(e) = result {
         match e {
-            chdb_rust::error::Error::QueryError(_) => {
-                assert!(true);
-            },
+            chdb_rust::error::Error::QueryError(_) => {}
             _ => {
-                panic!("Expected QueryError, got {:?}", e);
+                panic!("Expected QueryError, got {e:?}");
             }
         }
     }
@@ -312,20 +309,23 @@ fn test_error_handling_invalid_syntax() {
 fn test_session_auto_cleanup() -> Result<()> {
     let tmp = tempdir::TempDir::new("chdb-rust")?;
     let data_path = tmp.path().to_path_buf();
-    
+
     {
         let session = SessionBuilder::new()
             .with_data_path(&data_path)
             .with_auto_cleanup(true)
             .build()?;
 
-        session.execute("CREATE DATABASE testdb; USE testdb", Some(&[Arg::MultiQuery]))?;
+        session.execute(
+            "CREATE DATABASE testdb; USE testdb",
+            Some(&[Arg::MultiQuery]),
+        )?;
         session.execute(
             "CREATE TABLE test (id UInt64) ENGINE = MergeTree() ORDER BY id",
             None,
         )?;
         session.execute("INSERT INTO test VALUES (1)", None)?;
-        
+
         // Session should exist and work
         let result = session.execute("SELECT COUNT(*) FROM test", None)?;
         assert_eq!(result.rows_read(), 1);
@@ -333,7 +333,7 @@ fn test_session_auto_cleanup() -> Result<()> {
         // Check the folder was created
         assert!(fs::metadata(&data_path).is_ok());
     } // Session dropped here, auto_cleanup should trigger
-    
+
     // Check the folder was deleted
     assert!(fs::metadata(&data_path).is_err());
 
@@ -348,7 +348,10 @@ fn test_complex_query_with_joins() -> Result<()> {
         .with_auto_cleanup(true)
         .build()?;
 
-    session.execute("CREATE DATABASE testdb; USE testdb", Some(&[Arg::MultiQuery]))?;
+    session.execute(
+        "CREATE DATABASE testdb; USE testdb",
+        Some(&[Arg::MultiQuery]),
+    )?;
 
     // Create orders table
     session.execute(
@@ -430,7 +433,10 @@ fn test_session_without_auto_cleanup() -> Result<()> {
         .with_auto_cleanup(false) // Explicitly disable cleanup
         .build()?;
 
-    session.execute("CREATE DATABASE testdb; USE testdb", Some(&[Arg::MultiQuery]))?;
+    session.execute(
+        "CREATE DATABASE testdb; USE testdb",
+        Some(&[Arg::MultiQuery]),
+    )?;
     session.execute(
         "CREATE TABLE test (id UInt64) ENGINE = MergeTree() ORDER BY id",
         None,
@@ -441,7 +447,7 @@ fn test_session_without_auto_cleanup() -> Result<()> {
     assert_eq!(result.rows_read(), 1);
 
     // Check the folder was not deleted
-    assert!(fs::metadata(&tmp.path()).is_ok());
+    assert!(fs::metadata(tmp.path()).is_ok());
 
     Ok(())
 }


### PR DESCRIPTION
 - Add clippy check to CI
 - Update crate readme
 - Add publish workflow
 - Make Clippy happy

Note: the main changes here are from `cargo fmt` and making clippy happy. Specifically, how format now allows for use of `println!("{var}")` so need for `println!("{}", var)`.

Also added a publish workflow but needs a crate token added as a env, I can't test that one really so might have to be a post merge test.