### PR TITLE
feat(arrow): add RecordBatch bulk insert via C Data Interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chdb-rust"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 authors = ["Auxten"]
 description = "chDB FFI bindings for Rust(Experimental)"
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["clickhouse", "chdb", "database", "embedded", "analytics"]
 
 [dependencies]
+arrow = { version = "54", features = ["ffi"] }
 thiserror = "1"
 
 [features]
@@ -25,7 +26,10 @@ flate2 = "1.0"
 tar = "0.4"
 
 [dev-dependencies]
+arrow = { version = "54", features = ["ffi"] }
+arrow-array = "54"
 tempdir = "0.3.7"
+tempfile = "3"
 
 [package.metadata.docs.rs]
 # docs.rs cannot download libchdb or link native libraries.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ readme = "README.md"
 keywords = ["clickhouse", "chdb", "database", "embedded", "analytics"]
 
 [dependencies]
-arrow = { version = "54", features = ["ffi"] }
+arrow = { version = "59", optional = true, features = ["ffi"] }
 thiserror = "1"
 
 [features]
+default = ["arrow"]
+# Apache Arrow bulk insert / stream registration (RecordBatch, FFI wrappers).
+arrow = ["dep:arrow"]
 # By default, we link dynamically.
 # Users can opt-in to static linking with --features static
 static = []
@@ -26,12 +29,32 @@ flate2 = "1.0"
 tar = "0.4"
 
 [dev-dependencies]
-arrow = { version = "54", features = ["ffi"] }
-arrow-array = "54"
+arrow = { version = "59", features = ["ffi"] }
 tempdir = "0.3.7"
 tempfile = "3"
+
+[[example]]
+name = "08_arrow_insert"
+required-features = ["arrow"]
+
+[[test]]
+name = "arrow_insert"
+required-features = ["arrow"]
+
+[[test]]
+name = "arrow_insert_bench"
+required-features = ["arrow"]
+
+[[test]]
+name = "arrow_stream"
+required-features = ["arrow"]
+
+[[test]]
+name = "arrow_stream_roundtrip"
+required-features = ["arrow"]
 
 [package.metadata.docs.rs]
 # docs.rs cannot download libchdb or link native libraries.
 # Setting DOCS_RS env var tells build.rs to skip native build steps.
+features = ["arrow"]
 rustc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ cargo test -- --test-threads=1
 - **Detailed documentation**: See [docs/examples.md](docs/examples.md) for comprehensive examples and explanations
 - **Test examples**: See [tests/](tests/) directory for additional usage examples
 
+## Arrow Bulk Insert
+
+The crate includes Apache Arrow bulk insert support via the `arrow` dependency. See [docs/examples.md](docs/examples.md#fast-bulk-inserts-arrow) for usage, or run:
+
+```bash
+cargo run --example 08_arrow_insert
+```
+
 ## Contributing
 
 We welcome contributions! Here's how you can help:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,20 @@ cargo test -- --test-threads=1
 
 ## Arrow Bulk Insert
 
-The crate includes Apache Arrow bulk insert support via the `arrow` dependency. See [docs/examples.md](docs/examples.md#fast-bulk-inserts-arrow) for usage, or run:
+Apache Arrow bulk insert is enabled by default via the `arrow` feature (Arrow 59). Import Arrow types through `chdb_rust::arrow` so your `RecordBatch` types match the crate:
+
+```rust
+use chdb_rust::arrow::array::{Int64Array, RecordBatch};
+use chdb_rust::arrow::datatypes::{DataType, Field, Schema};
+```
+
+SQL-only users can disable it to avoid building Arrow:
+
+```toml
+chdb-rust = { version = "1.4", default-features = false }
+```
+
+See [docs/examples.md](docs/examples.md#fast-bulk-inserts-arrow) for usage, or run:
 
 ```bash
 cargo run --example 08_arrow_insert

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(direct_arrow_insert)");
+
     if env::var("DOCS_RS").is_ok() {
         return;
     }
@@ -13,7 +15,7 @@ fn main() {
     let libchdb_info = find_libchdb_or_download(&out_path);
     match libchdb_info {
         Ok((lib_dir, header_path)) => {
-            setup_link_paths(&lib_dir);
+            setup_link_paths(&lib_dir, &header_path);
             generate_bindings(&header_path, &out_path);
         }
         Err(e) => {
@@ -136,7 +138,30 @@ fn get_platform_string() -> Result<String, &'static str> {
     }
 }
 
-fn setup_link_paths(lib_dir: &Path) {
+fn lib_exports_symbol(lib_dir: &Path, symbol: &str) -> bool {
+    let lib_path = lib_dir.join("libchdb.so");
+    if !lib_path.exists() {
+        return false;
+    }
+    let output = Command::new("nm")
+        .args(["-D", lib_path.to_str().unwrap_or_default()])
+        .output();
+    match output {
+        Ok(o) if o.status.success() => {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            stdout.contains(symbol)
+        }
+        _ => false,
+    }
+}
+
+fn header_declares_direct_insert(header_path: &Path) -> bool {
+    fs::read_to_string(header_path)
+        .map(|s| s.contains("chdb_insert_arrow_array"))
+        .unwrap_or(false)
+}
+
+fn setup_link_paths(lib_dir: &Path, header_path: &Path) {
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
     println!("cargo:rustc-link-search=native=./");
     println!("cargo:rustc-link-search=native=/usr/local/lib");
@@ -162,11 +187,27 @@ fn setup_link_paths(lib_dir: &Path) {
         println!("cargo:rustc-link-lib=chdb");
     }
 
+    if header_declares_direct_insert(header_path)
+        && lib_exports_symbol(lib_dir, "chdb_insert_arrow_array")
+    {
+        println!("cargo:rustc-cfg=direct_arrow_insert");
+    }
+
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", header_path.display());
+    if lib_dir.join("libchdb.so").exists() {
+        println!(
+            "cargo:rerun-if-changed={}",
+            lib_dir.join("libchdb.so").display()
+        );
+    }
 }
 
 fn generate_bindings(header_path: &Path, out_dir: &Path) {
+    let header_path = header_path
+        .canonicalize()
+        .unwrap_or_else(|_| header_path.to_path_buf());
     let wrapper_content = format!("#include \"{}\"", header_path.display());
     let temp_wrapper = out_dir.join("temp_wrapper.h");
     if fs::read_to_string(&temp_wrapper)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -365,8 +365,8 @@ In Rust, build the expression with `arrow_stream_table_sql("my_batch")`.
 
 ```rust
 use std::sync::Arc;
-use arrow::array::{Int64Array, RecordBatch};
-use arrow::datatypes::{DataType, Field, Schema};
+use chdb_rust::arrow::array::{Int64Array, RecordBatch};
+use chdb_rust::arrow::datatypes::{DataType, Field, Schema};
 use chdb_rust::arrow_insert::insert_record_batch;
 use chdb_rust::session::SessionBuilder;
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,6 +11,7 @@ This document provides simple and easy-to-follow examples for using chdb-rust, a
 5. [Output Formats](#output-formats)
 6. [Reading from Files](#reading-from-files)
 7. [Error Handling](#error-handling)
+8. [Fast Bulk Inserts (Arrow)](#fast-bulk-inserts-arrow)
 
 ## Basic Setup
 
@@ -321,6 +322,77 @@ fn main() -> Result<(), chdb_rust::error::Error> {
     Ok(())
 }
 ```
+
+## Fast Bulk Inserts (Arrow)
+
+For high throughput and low latency, register in-memory Arrow data and insert with `INSERT ... SELECT` from the `ArrowStream` table function. This avoids temp-file Arrow IPC and SQL `VALUES` parsing.
+
+### Ranked ingest paths
+
+| Rank | Method | Notes |
+|------|--------|-------|
+| 1 | `register_arrow_stream` + `INSERT INTO dest SELECT * FROM ArrowStream('n')` | Multi-batch; no disk hop |
+| 2 | `register_arrow_array` + same SQL | Single `RecordBatch` |
+| 3 | `file(path, 'Native')` | Pre-encoded Native files |
+| 4 | `file(path, 'RowBinary')` | Dense binary; requires `structure` in SQL |
+| 5 | `file(path, 'ArrowStream')` | Arrow IPC on disk |
+| 6 | `file(path, 'Parquet')` | Cold bulk loads |
+| 7 | `INSERT ... VALUES` | Fine for demos; worst at scale |
+
+`OutputFormat` on `query()` / `execute()` affects **result** encoding only, not ingest speed.
+
+### SQL syntax
+
+Registration exposes a **table function**, not a MergeTree table:
+
+```sql
+-- Correct
+INSERT INTO dest SELECT * FROM ArrowStream('my_batch');
+
+-- Wrong (UNKNOWN_TABLE)
+SELECT * FROM my_batch;
+```
+
+In Rust, build the expression with `arrow_stream_table_sql("my_batch")`.
+
+### FFI lifetime rules
+
+- Pass raw `FFI_ArrowArrayStream` / `FFI_ArrowSchema` / `FFI_ArrowArray` pointers via [`ArrowStream::from_raw`](https://docs.rs/chdb-rust/latest/chdb_rust/arrow_stream/struct.ArrowStream.html) (not the opaque `chdb_arrow_stream_` typedef in `chdb.h`).
+- Keep backing `RecordBatch` data and FFI structs alive until `unregister_arrow_table` or the connection closes.
+- `chdb_arrow_scan` does not take ownership of the stream; do not free it before unregister.
+
+### High-level helpers
+
+```rust
+use std::sync::Arc;
+use arrow::array::{Int64Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use chdb_rust::arrow_insert::insert_record_batch;
+use chdb_rust::session::SessionBuilder;
+
+let session = SessionBuilder::new()
+    .with_data_path("/tmp/chdb-ingest")
+    .with_auto_cleanup(true)
+    .build()?;
+
+session.execute(
+    "CREATE TABLE IF NOT EXISTS metrics (id Int64) ENGINE=MergeTree ORDER BY id",
+    None,
+)?;
+
+let batch = RecordBatch::try_new(
+    Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+    vec![Arc::new(Int64Array::from(vec![1i64, 2, 3]))],
+)?;
+
+session.insert_record_batch("metrics", "flush_1", &batch)?;
+```
+
+`insert_record_batches` accepts multiple batches via an Arrow `RecordBatchReader`.
+
+`dest_table` must be a bare ClickHouse table identifier (e.g. `metrics`); dotted names (`db.table`) and reserved words are not quoted automatically.
+
+See `examples/08_arrow_insert.rs` for a runnable program.
 
 ## Additional Resources
 

--- a/examples/08_arrow_insert.rs
+++ b/examples/08_arrow_insert.rs
@@ -34,9 +34,7 @@ fn main() -> Result<(), chdb_rust::error::Error> {
         schema,
         vec![
             Arc::new(Int64Array::from(vec![1i64, 2, 3, 4, 5])),
-            Arc::new(Float64Array::from(vec![
-                10.0, 20.0, 30.0, 40.0, 50.0,
-            ])),
+            Arc::new(Float64Array::from(vec![10.0, 20.0, 30.0, 40.0, 50.0])),
         ],
     )
     .map_err(|e| chdb_rust::error::Error::QueryError(e.to_string()))?;

--- a/examples/08_arrow_insert.rs
+++ b/examples/08_arrow_insert.rs
@@ -4,8 +4,8 @@
 
 use std::sync::Arc;
 
-use arrow::array::{Int64Array, RecordBatch};
-use arrow::datatypes::{DataType, Field, Schema};
+use chdb_rust::arrow::array::{Float64Array, Int64Array, RecordBatch};
+use chdb_rust::arrow::datatypes::{DataType, Field, Schema};
 
 use chdb_rust::arg::Arg;
 use chdb_rust::format::OutputFormat;
@@ -34,7 +34,7 @@ fn main() -> Result<(), chdb_rust::error::Error> {
         schema,
         vec![
             Arc::new(Int64Array::from(vec![1i64, 2, 3, 4, 5])),
-            Arc::new(arrow::array::Float64Array::from(vec![
+            Arc::new(Float64Array::from(vec![
                 10.0, 20.0, 30.0, 40.0, 50.0,
             ])),
         ],

--- a/examples/08_arrow_insert.rs
+++ b/examples/08_arrow_insert.rs
@@ -1,0 +1,64 @@
+//! Fast bulk insert: RecordBatch → ArrowStream registration → MergeTree.
+//!
+//! Run: cargo run --example 08_arrow_insert
+
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+
+use chdb_rust::arg::Arg;
+use chdb_rust::format::OutputFormat;
+use chdb_rust::session::SessionBuilder;
+use chdb_rust::InsertOptions;
+
+fn main() -> Result<(), chdb_rust::error::Error> {
+    let data_dir = std::env::temp_dir().join("chdb-rust-arrow-insert-example");
+    let session = SessionBuilder::new()
+        .with_data_path(&data_dir)
+        .with_auto_cleanup(true)
+        .build()?;
+
+    session.execute(
+        "CREATE TABLE IF NOT EXISTS metrics (id Int64, value Float64) \
+         ENGINE = MergeTree ORDER BY id",
+        None,
+    )?;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Float64, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1i64, 2, 3, 4, 5])),
+            Arc::new(arrow::array::Float64Array::from(vec![
+                10.0, 20.0, 30.0, 40.0, 50.0,
+            ])),
+        ],
+    )
+    .map_err(|e| chdb_rust::error::Error::QueryError(e.to_string()))?;
+
+    session.insert_record_batch(
+        "metrics",
+        "example_batch",
+        batch,
+        InsertOptions::default_bulk(),
+    )?;
+
+    let count = session.execute(
+        "SELECT count() AS c FROM metrics",
+        Some(&[Arg::OutputFormat(OutputFormat::TabSeparated)]),
+    )?;
+    println!("Row count after Arrow insert: {}", count.data_utf8_lossy());
+
+    let sum = session.execute(
+        "SELECT sum(value) FROM metrics",
+        Some(&[Arg::OutputFormat(OutputFormat::TabSeparated)]),
+    )?;
+    println!("Sum(value): {}", sum.data_utf8_lossy());
+
+    Ok(())
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ cargo run --example 04_output_formats
 cargo run --example 05_reading_from_files
 cargo run --example 06_error_handling
 cargo run --example 07_analytics
+cargo run --example 08_arrow_insert
 ```
 
 ## Example Files
@@ -25,6 +26,7 @@ cargo run --example 07_analytics
 5. **05_reading_from_files.rs** - Querying data from CSV and JSON files
 6. **06_error_handling.rs** - Proper error handling patterns
 7. **07_analytics.rs** - Complete analytics example with event tracking and aggregation
+8. **08_arrow_insert.rs** - Fast bulk insert via Arrow C Data Interface (`insert_record_batch`)
 
 ## Prerequisites
 

--- a/src/arrow_insert.rs
+++ b/src/arrow_insert.rs
@@ -1,0 +1,343 @@
+//! High-throughput inserts via Arrow C Data Interface registration.
+//!
+//! Wraps [`Connection::register_arrow_stream`](crate::connection::Connection::register_arrow_stream),
+//! [`Connection::register_arrow_array`](crate::connection::Connection::register_arrow_array),
+//! and `INSERT INTO … SELECT * FROM ArrowStream('name')`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use arrow::array::RecordBatchReader;
+use arrow::array::{RecordBatch, RecordBatchIterator, StructArray};
+use arrow::datatypes::SchemaRef;
+use arrow::ffi::{to_ffi, FFI_ArrowArray, FFI_ArrowSchema};
+use arrow::ffi_stream::FFI_ArrowArrayStream;
+
+use crate::arrow_options::InsertOptions;
+use crate::arrow_stream::{arrow_stream_table_sql, ArrowArray, ArrowSchema, ArrowStream};
+use crate::connection::Connection;
+use crate::error::Result;
+use crate::format::OutputFormat;
+
+static FALLBACK_STREAM_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Owns Arrow C Data Interface structs for the lifetime of a registration or insert.
+struct OwnedArrowArray {
+    ffi_schema: FFI_ArrowSchema,
+    ffi_array: FFI_ArrowArray,
+}
+
+impl OwnedArrowArray {
+    fn from_batch(batch: RecordBatch) -> Result<Self> {
+        let struct_array = StructArray::from(batch);
+        let (ffi_array, ffi_schema) = to_ffi(&struct_array.into())
+            .map_err(|e| crate::error::Error::QueryError(e.to_string()))?;
+        Ok(Self {
+            ffi_schema,
+            ffi_array,
+        })
+    }
+
+    fn schema(&self) -> ArrowSchema {
+        unsafe { ArrowSchema::from_raw(&self.ffi_schema as *const _ as *mut _) }
+    }
+
+    fn array(&self) -> ArrowArray {
+        unsafe { ArrowArray::from_raw(&self.ffi_array as *const _ as *mut _) }
+    }
+}
+
+/// Backtick-quoted `(col1, col2, ...)` clause from an Arrow schema, or empty when
+/// the schema has no fields. Emitted on the `INSERT` so ClickHouse maps the Arrow
+/// columns to destination columns **by name**. Without it, `SELECT *` maps by
+/// position, which silently scatters values into the wrong columns whenever the
+/// table's physical column order differs from the batch's (e.g. after
+/// `ALTER TABLE ... ADD COLUMN`, which appends rather than preserving order).
+///
+/// The direct FFI path (`chdb_insert_arrow_array`) already matches by name via
+/// ClickHouse's Arrow input format; this keeps the SQL fallback consistent.
+fn column_list_clause(schema: &arrow::datatypes::Schema) -> String {
+    if schema.fields().is_empty() {
+        return String::new();
+    }
+    let cols = schema
+        .fields()
+        .iter()
+        .map(|f| format!("`{}`", f.name().replace('`', "``")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(" ({cols})")
+}
+
+fn insert_from_registered(
+    conn: &Connection,
+    dest_table: &str,
+    stream_name: &str,
+    columns: &str,
+    options: &InsertOptions,
+) -> Result<()> {
+    let mut sql = format!(
+        "INSERT INTO {dest_table}{columns} SELECT * FROM {}",
+        arrow_stream_table_sql(stream_name)
+    );
+    if let Some(settings) = options.settings_clause() {
+        sql.push_str(" SETTINGS ");
+        sql.push_str(&settings);
+    }
+    conn.query(&sql, OutputFormat::Null)?;
+    Ok(())
+}
+
+fn insert_via_registered_array(
+    conn: &Connection,
+    dest_table: &str,
+    stream_name: &str,
+    arrow_schema: &ArrowSchema,
+    arrow_array: &ArrowArray,
+    columns: &str,
+    options: &InsertOptions,
+) -> Result<()> {
+    conn.register_arrow_array(stream_name, arrow_schema, arrow_array)?;
+    let result = insert_from_registered(conn, dest_table, stream_name, columns, options);
+    conn.unregister_arrow_table(stream_name)?;
+    result
+}
+
+/// Insert a single [`RecordBatch`] into `dest_table` via `register_arrow_array`.
+///
+/// `stream_name` is a temporary registration label (not a MergeTree table name).
+/// `dest_table` must be a bare ClickHouse table identifier (e.g. `metrics`);
+/// dotted names (`db.table`) and reserved identifiers are not quoted automatically.
+/// Uses the fastest one-shot Arrow path for a single in-memory batch.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use arrow::array::{Int64Array, RecordBatch};
+/// use arrow::datatypes::{DataType, Field, Schema};
+/// use chdb_rust::arrow_insert::insert_record_batch;
+/// use chdb_rust::InsertOptions;
+/// use chdb_rust::connection::Connection;
+///
+/// let conn = Connection::open_in_memory()?;
+/// conn.query(
+///     "CREATE TABLE metrics (id Int64) ENGINE=MergeTree ORDER BY id",
+///     chdb_rust::format::OutputFormat::TabSeparated,
+/// )?;
+///
+/// let batch = RecordBatch::try_new(
+///     Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+///     vec![Arc::new(Int64Array::from(vec![1i64, 2, 3]))],
+/// )
+/// .map_err(|e| chdb_rust::error::Error::QueryError(e.to_string()))?;
+///
+/// insert_record_batch(&conn, "metrics", "flush_1", batch, InsertOptions::default_bulk())?;
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if registration, the insert query, or unregistration fails.
+pub fn insert_record_batch(
+    conn: &Connection,
+    dest_table: &str,
+    stream_name: &str,
+    batch: RecordBatch,
+    options: InsertOptions,
+) -> Result<()> {
+    let columns = column_list_clause(batch.schema().as_ref());
+    let handles = OwnedArrowArray::from_batch(batch)?;
+    insert_via_registered_array(
+        conn,
+        dest_table,
+        stream_name,
+        &handles.schema(),
+        &handles.array(),
+        &columns,
+        &options,
+    )
+}
+
+/// Insert a single [`RecordBatch`] using the direct `chdb_insert_arrow_array` FFI when
+/// available, falling back to register + SQL + unregister otherwise.
+///
+/// Unlike [`insert_record_batch`], no temporary `stream_name` is required on the direct path.
+/// This is the recommended entry point for single-batch ingest.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use arrow::array::{Int64Array, RecordBatch};
+/// use arrow::datatypes::{DataType, Field, Schema};
+/// use chdb_rust::arrow_insert::insert_record_batch_direct;
+/// use chdb_rust::InsertOptions;
+/// use chdb_rust::connection::Connection;
+///
+/// let conn = Connection::open_in_memory()?;
+/// conn.query(
+///     "CREATE TABLE metrics (id Int64) ENGINE=MergeTree ORDER BY id",
+///     chdb_rust::format::OutputFormat::TabSeparated,
+/// )?;
+///
+/// let batch = RecordBatch::try_new(
+///     Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+///     vec![Arc::new(Int64Array::from(vec![1i64, 2, 3]))],
+/// )
+/// .map_err(|e| chdb_rust::error::Error::QueryError(e.to_string()))?;
+///
+/// insert_record_batch_direct(&conn, "metrics", batch, InsertOptions::default_bulk())?;
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+pub fn insert_record_batch_direct(
+    conn: &Connection,
+    dest_table: &str,
+    batch: RecordBatch,
+    options: InsertOptions,
+) -> Result<()> {
+    let columns = column_list_clause(batch.schema().as_ref());
+    let handles = OwnedArrowArray::from_batch(batch)?;
+
+    #[cfg(direct_arrow_insert)]
+    {
+        let _ = &columns;
+        return conn.insert_arrow_array(dest_table, &handles.schema(), &handles.array(), &options);
+    }
+
+    #[cfg(not(direct_arrow_insert))]
+    {
+        let stream_name = format!(
+            "__rust_direct_{}",
+            FALLBACK_STREAM_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        insert_via_registered_array(
+            conn,
+            dest_table,
+            &stream_name,
+            &handles.schema(),
+            &handles.array(),
+            &columns,
+            &options,
+        )
+    }
+}
+
+/// Insert multiple [`RecordBatch`] values via `register_arrow_stream`.
+///
+/// `batches` must share the same schema as `schema`. Prefer this when a flush
+/// spans more than one batch. See [`insert_record_batch`] for `dest_table` constraints.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use arrow::array::{Int64Array, RecordBatch};
+/// use arrow::datatypes::{DataType, Field, Schema};
+/// use chdb_rust::arrow_insert::insert_record_batches;
+/// use chdb_rust::InsertOptions;
+/// use chdb_rust::connection::Connection;
+///
+/// let conn = Connection::open_in_memory()?;
+/// conn.query(
+///     "CREATE TABLE metrics (id Int64) ENGINE=MergeTree ORDER BY id",
+///     chdb_rust::format::OutputFormat::TabSeparated,
+/// )?;
+///
+/// let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+/// let batches = vec![
+///     RecordBatch::try_new(
+///         Arc::clone(&schema),
+///         vec![Arc::new(Int64Array::from(vec![1i64, 2]))],
+///     )
+///     .map_err(|e| chdb_rust::error::Error::QueryError(e.to_string()))?,
+///     RecordBatch::try_new(
+///         Arc::clone(&schema),
+///         vec![Arc::new(Int64Array::from(vec![3i64, 4]))],
+///     )
+///     .map_err(|e| chdb_rust::error::Error::QueryError(e.to_string()))?,
+/// ];
+///
+/// insert_record_batches(
+///     &conn,
+///     "metrics",
+///     "flush_multi",
+///     schema,
+///     batches,
+///     InsertOptions::default_bulk(),
+/// )?;
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+pub fn insert_record_batches(
+    conn: &Connection,
+    dest_table: &str,
+    stream_name: &str,
+    schema: SchemaRef,
+    batches: Vec<RecordBatch>,
+    options: InsertOptions,
+) -> Result<()> {
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+    insert_record_batch_reader(conn, dest_table, stream_name, Box::new(reader), options)
+}
+
+/// Insert from any [`RecordBatchReader`] via `register_arrow_stream`, or direct FFI when available.
+///
+/// See [`insert_record_batch`] for `dest_table` constraints.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use arrow::array::{Int64Array, RecordBatch, RecordBatchIterator};
+/// use arrow::datatypes::{DataType, Field, Schema};
+/// use chdb_rust::arrow_insert::insert_record_batch_reader;
+/// use chdb_rust::InsertOptions;
+/// use chdb_rust::connection::Connection;
+///
+/// let conn = Connection::open_in_memory()?;
+/// conn.query(
+///     "CREATE TABLE metrics (id Int64) ENGINE=MergeTree ORDER BY id",
+///     chdb_rust::format::OutputFormat::TabSeparated,
+/// )?;
+///
+/// let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+/// let batch = RecordBatch::try_new(
+///     Arc::clone(&schema),
+///     vec![Arc::new(Int64Array::from(vec![1i64, 2]))],
+/// )
+/// .map_err(|e| chdb_rust::error::Error::QueryError(e.to_string()))?;
+/// let reader = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema);
+///
+/// insert_record_batch_reader(
+///     &conn,
+///     "metrics",
+///     "flush_reader",
+///     Box::new(reader),
+///     InsertOptions::default_bulk(),
+/// )?;
+/// # Ok::<(), chdb_rust::error::Error>(())
+/// ```
+pub fn insert_record_batch_reader(
+    conn: &Connection,
+    dest_table: &str,
+    stream_name: &str,
+    reader: Box<dyn RecordBatchReader + Send>,
+    options: InsertOptions,
+) -> Result<()> {
+    let columns = column_list_clause(reader.schema().as_ref());
+    let mut ffi_stream = FFI_ArrowArrayStream::new(reader);
+    let arrow_stream = unsafe { ArrowStream::from_raw(&mut ffi_stream) };
+
+    #[cfg(direct_arrow_insert)]
+    {
+        let _ = (stream_name, &columns);
+        return conn.insert_arrow_stream(dest_table, &arrow_stream, &options);
+    }
+
+    #[cfg(not(direct_arrow_insert))]
+    {
+        conn.register_arrow_stream(stream_name, &arrow_stream)?;
+        let result = insert_from_registered(conn, dest_table, stream_name, &columns, &options);
+        conn.unregister_arrow_table(stream_name)?;
+        result
+    }
+}

--- a/src/arrow_options.rs
+++ b/src/arrow_options.rs
@@ -1,0 +1,61 @@
+//! Shared options for Arrow bulk insert paths.
+
+/// Tuning knobs appended as `SETTINGS` on the insert `INSERT … SELECT` query,
+/// or passed to direct FFI insert APIs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InsertOptions {
+    /// `max_threads` insert setting (default: 4).
+    pub max_threads: Option<u32>,
+    /// `max_insert_block_size` insert setting.
+    pub max_insert_block_size: Option<u64>,
+    /// `min_insert_block_size_rows` insert setting.
+    pub min_insert_block_size_rows: Option<u64>,
+}
+
+impl InsertOptions {
+    /// Sensible defaults for bulk Arrow ingest.
+    pub fn default_bulk() -> Self {
+        Self {
+            max_threads: Some(4),
+            max_insert_block_size: None,
+            min_insert_block_size_rows: None,
+        }
+    }
+
+    pub(crate) fn settings_clause(&self) -> Option<String> {
+        let mut parts = Vec::new();
+        if let Some(v) = self.max_threads {
+            parts.push(format!("max_threads = {v}"));
+        }
+        if let Some(v) = self.max_insert_block_size {
+            parts.push(format!("max_insert_block_size = {v}"));
+        }
+        if let Some(v) = self.min_insert_block_size_rows {
+            parts.push(format!("min_insert_block_size_rows = {v}"));
+        }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join(", "))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_options_settings_clause() {
+        let opts = InsertOptions {
+            max_threads: Some(4),
+            max_insert_block_size: Some(1_048_576),
+            min_insert_block_size_rows: None,
+        };
+        assert_eq!(
+            opts.settings_clause().as_deref(),
+            Some("max_threads = 4, max_insert_block_size = 1048576")
+        );
+        assert!(InsertOptions::default().settings_clause().is_none());
+    }
+}

--- a/src/arrow_stream.rs
+++ b/src/arrow_stream.rs
@@ -1,193 +1,224 @@
 //! Arrow streaming support for chDB.
 //!
-//! This module provides types and functions for registering Arrow streams and arrays
-//! as table functions in chDB, enabling efficient data transfer between Arrow
-//! and ClickHouse formats.
+//! Registered streams are queried via the ClickHouse table function
+//! `ArrowStream('name')`, not as bare table identifiers.
+//!
+//! libchdb's `chdb_arrow_scan` / `chdb_arrow_array_scan` take raw Arrow C Data
+//! Interface pointers (`ArrowArrayStream*`, `ArrowSchema*`, `ArrowArray*`).
+//! The `chdb_arrow_*` typedefs in `chdb.h` are misleading wrappers; pass pointers
+//! to the actual FFI structs (e.g. from the `arrow` crate).
 //!
 //! # Overview
 //!
 //! Arrow streaming allows you to:
-//! - Register Arrow streams as virtual tables that can be queried with SQL
-//! - Register Arrow arrays as virtual tables
-//! - Unregister tables when done
+//! - Register Arrow streams as virtual table functions queryable with SQL
+//! - Register Arrow schema+array pairs as one-shot streams
+//! - Unregister names when done
 //!
 //! # Examples
 //!
 //! ```no_run
+//! use chdb_rust::arrow_stream::{arrow_stream_table_sql, ArrowStream};
 //! use chdb_rust::connection::Connection;
-//! use chdb_rust::arrow_stream::{ArrowStream, ArrowSchema, ArrowArray};
+//! use chdb_rust::format::OutputFormat;
 //!
-//! // Create a connection
 //! let conn = Connection::open_in_memory()?;
 //!
-//! // Register an Arrow stream as a table (assuming you have an Arrow stream handle)
-//! // let arrow_stream = ArrowStream::from_raw(stream_ptr);
-//! // conn.register_arrow_stream("my_table", &arrow_stream)?;
+//! // Register an Arrow stream (assuming you have an Arrow C Data Interface handle)
+//! // let arrow_stream = unsafe { ArrowStream::from_raw(stream_ptr) };
+//! // conn.register_arrow_stream("my_data", &arrow_stream)?;
 //!
-//! // Query the registered table
-//! // let result = conn.query("SELECT * FROM my_table", OutputFormat::JSONEachRow)?;
+//! // Query via the ArrowStream table function, not a bare table name
+//! // let sql = format!("SELECT * FROM {}", arrow_stream_table_sql("my_data"));
+//! // let result = conn.query(&sql, OutputFormat::JSONEachRow)?;
 //!
 //! // Unregister when done
-//! // conn.unregister_arrow_table("my_table")?;
+//! // conn.unregister_arrow_table("my_data")?;
 //! # Ok::<(), chdb_rust::error::Error>(())
 //! ```
 
 use crate::bindings;
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow::ffi_stream::FFI_ArrowArrayStream;
 
-/// A handle to an Arrow stream.
+/// Raw Arrow C Data Interface stream pointer expected by `chdb_arrow_scan`.
+pub type RawArrowArrayStream = *mut FFI_ArrowArrayStream;
+
+/// Raw Arrow C Data Interface schema pointer expected by `chdb_arrow_array_scan`.
+pub type RawArrowSchema = *mut FFI_ArrowSchema;
+
+/// Raw Arrow C Data Interface array pointer expected by `chdb_arrow_array_scan`.
+pub type RawArrowArray = *mut FFI_ArrowArray;
+
+/// A handle to an Arrow C Data Interface `ArrowArrayStream`.
 ///
-/// This is a wrapper around the opaque `chdb_arrow_stream` pointer type.
-/// Arrow streams are typically created from Arrow C++ or other Arrow implementations.
+/// Arrow streams are typically created from the `arrow` crate or other Arrow
+/// implementations that export the C Data Interface.
 ///
 /// # Safety
 ///
-/// The underlying pointer must be valid and must remain valid for the lifetime
-/// of this handle. The handle does not take ownership of the Arrow stream.
+/// The pointer must remain valid until the stream is unregistered or the
+/// connection is closed. chDB does not take ownership (`chdb_arrow_scan` passes
+/// `is_owner = false`).
 #[derive(Debug, Clone, Copy)]
 pub struct ArrowStream {
-    inner: bindings::chdb_arrow_stream,
+    inner: RawArrowArrayStream,
 }
 
 unsafe impl Send for ArrowStream {}
 
 impl ArrowStream {
-    /// Create an `ArrowStream` from a raw `chdb_arrow_stream` pointer.
+    /// Create an [`ArrowStream`] from a raw `ArrowArrayStream` pointer.
     ///
     /// # Safety
     ///
-    /// The pointer must be valid and point to a valid Arrow stream handle.
-    /// The caller is responsible for ensuring the stream remains valid for
-    /// the lifetime of this handle.
+    /// `stream` must be a valid, non-null `ArrowArrayStream` for the lifetime of
+    /// this handle (and until chDB unregisters the name).
     ///
     /// # Arguments
     ///
-    /// * `stream` - A raw pointer to a `chdb_arrow_stream`
+    /// * `stream` - A raw pointer to an `FFI_ArrowArrayStream`
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use chdb_rust::arrow_stream::ArrowStream;
     ///
-    /// // Assuming you have a valid Arrow stream pointer from Arrow C++
-    /// // let stream_ptr: *mut chdb_arrow_stream_ = ...;
+    /// // Assuming you have a valid Arrow C Data Interface stream pointer
+    /// // let stream_ptr: *mut arrow::ffi_stream::FFI_ArrowArrayStream = ...;
     /// // let arrow_stream = unsafe { ArrowStream::from_raw(stream_ptr) };
     /// ```
-    pub unsafe fn from_raw(stream: bindings::chdb_arrow_stream) -> Self {
+    pub unsafe fn from_raw(stream: RawArrowArrayStream) -> Self {
         Self { inner: stream }
     }
 
-    /// Get the raw pointer to the underlying Arrow stream handle.
+    /// Returns the raw pointer passed through to `chdb_arrow_scan`.
     ///
     /// # Returns
     ///
-    /// Returns the raw `chdb_arrow_stream` pointer.
+    /// Returns the raw `ArrowArrayStream` pointer.
     pub fn as_raw(&self) -> bindings::chdb_arrow_stream {
-        self.inner
+        self.inner.cast()
     }
 }
 
-/// A handle to an Arrow schema.
+/// A handle to an Arrow C Data Interface `ArrowSchema`.
 ///
-/// This is a wrapper around the opaque `chdb_arrow_schema` pointer type.
 /// Arrow schemas define the structure of Arrow data.
 ///
 /// # Safety
 ///
-/// The underlying pointer must be valid and must remain valid for the lifetime
-/// of this handle. The handle does not take ownership of the Arrow schema.
+/// The pointer must remain valid through registration and any queries that read
+/// the registered stream.
 #[derive(Debug, Clone, Copy)]
 pub struct ArrowSchema {
-    inner: bindings::chdb_arrow_schema,
+    inner: RawArrowSchema,
 }
 
 unsafe impl Send for ArrowSchema {}
 
 impl ArrowSchema {
-    /// Create an `ArrowSchema` from a raw `chdb_arrow_schema` pointer.
+    /// Create an [`ArrowSchema`] from a raw `ArrowSchema` pointer.
     ///
     /// # Safety
     ///
-    /// The pointer must be valid and point to a valid Arrow schema handle.
-    /// The caller is responsible for ensuring the schema remains valid for
-    /// the lifetime of this handle.
+    /// `schema` must be a valid, non-null `ArrowSchema` pointer.
     ///
     /// # Arguments
     ///
-    /// * `schema` - A raw pointer to a `chdb_arrow_schema`
+    /// * `schema` - A raw pointer to an `FFI_ArrowSchema`
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use chdb_rust::arrow_stream::ArrowSchema;
     ///
-    /// // Assuming you have a valid Arrow schema pointer from Arrow C++
-    /// // let schema_ptr: *mut chdb_arrow_schema_ = ...;
+    /// // Assuming you have a valid Arrow C Data Interface schema pointer
+    /// // let schema_ptr: *mut arrow::ffi::FFI_ArrowSchema = ...;
     /// // let arrow_schema = unsafe { ArrowSchema::from_raw(schema_ptr) };
     /// ```
-    pub unsafe fn from_raw(schema: bindings::chdb_arrow_schema) -> Self {
+    pub unsafe fn from_raw(schema: RawArrowSchema) -> Self {
         Self { inner: schema }
     }
 
-    /// Get the raw pointer to the underlying Arrow schema handle.
+    /// Returns the raw pointer passed through to `chdb_arrow_array_scan`.
     ///
     /// # Returns
     ///
-    /// Returns the raw `chdb_arrow_schema` pointer.
+    /// Returns the raw `ArrowSchema` pointer.
     pub fn as_raw(&self) -> bindings::chdb_arrow_schema {
-        self.inner
+        self.inner.cast()
     }
 }
 
-/// A handle to an Arrow array.
+/// A handle to an Arrow C Data Interface `ArrowArray`.
 ///
-/// This is a wrapper around the opaque `chdb_arrow_array` pointer type.
 /// Arrow arrays contain the actual data in Arrow format.
 ///
 /// # Safety
 ///
-/// The underlying pointer must be valid and must remain valid for the lifetime
-/// of this handle. The handle does not take ownership of the Arrow array.
+/// The pointer must remain valid through registration and any queries that read
+/// the registered stream.
 #[derive(Debug, Clone, Copy)]
 pub struct ArrowArray {
-    inner: bindings::chdb_arrow_array,
+    inner: RawArrowArray,
 }
 
 unsafe impl Send for ArrowArray {}
 
 impl ArrowArray {
-    /// Create an `ArrowArray` from a raw `chdb_arrow_array` pointer.
+    /// Create an [`ArrowArray`] from a raw `ArrowArray` pointer.
     ///
     /// # Safety
     ///
-    /// The pointer must be valid and point to a valid Arrow array handle.
-    /// The caller is responsible for ensuring the array remains valid for
-    /// the lifetime of this handle.
+    /// `array` must be a valid, non-null `ArrowArray` pointer.
     ///
     /// # Arguments
     ///
-    /// * `array` - A raw pointer to a `chdb_arrow_array`
+    /// * `array` - A raw pointer to an `FFI_ArrowArray`
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use chdb_rust::arrow_stream::ArrowArray;
     ///
-    /// // Assuming you have a valid Arrow array pointer from Arrow C++
-    /// // let array_ptr: *mut chdb_arrow_array_ = ...;
+    /// // Assuming you have a valid Arrow C Data Interface array pointer
+    /// // let array_ptr: *mut arrow::ffi::FFI_ArrowArray = ...;
     /// // let arrow_array = unsafe { ArrowArray::from_raw(array_ptr) };
     /// ```
-    pub unsafe fn from_raw(array: bindings::chdb_arrow_array) -> Self {
+    pub unsafe fn from_raw(array: RawArrowArray) -> Self {
         Self { inner: array }
     }
 
-    /// Get the raw pointer to the underlying Arrow array handle.
+    /// Returns the raw pointer passed through to `chdb_arrow_array_scan`.
     ///
     /// # Returns
     ///
-    /// Returns the raw `chdb_arrow_array` pointer.
+    /// Returns the raw `ArrowArray` pointer.
     pub fn as_raw(&self) -> bindings::chdb_arrow_array {
-        self.inner
+        self.inner.cast()
     }
+}
+
+/// SQL table-expression for a registered Arrow stream name.
+///
+/// Registered names are exposed as the `ArrowStream` table function, not as
+/// ordinary tables. Use this when building `INSERT ... SELECT` or ad-hoc queries.
+///
+/// # Example
+///
+/// ```
+/// use chdb_rust::arrow_stream::arrow_stream_table_sql;
+///
+/// let sql = format!(
+///     "INSERT INTO dest SELECT * FROM {}",
+///     arrow_stream_table_sql("my_batch")
+/// );
+/// assert_eq!(sql, "INSERT INTO dest SELECT * FROM ArrowStream('my_batch')");
+/// ```
+pub fn arrow_stream_table_sql(table_name: &str) -> String {
+    let escaped = table_name.replace('\'', "''");
+    format!("ArrowStream('{escaped}')")
 }
 
 #[cfg(test)]
@@ -195,25 +226,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_arrow_stream_from_raw() {
-        // Test that we can create an ArrowStream from a null pointer
-        // (this is just testing the API, not actual functionality)
-        let null_ptr = std::ptr::null_mut();
-        let stream = unsafe { ArrowStream::from_raw(null_ptr) };
+    fn arrow_stream_table_sql_escapes_quotes() {
+        assert_eq!(arrow_stream_table_sql("a'b"), "ArrowStream('a''b')");
+    }
+
+    #[test]
+    fn arrow_stream_from_raw_accepts_null() {
+        let stream = unsafe { ArrowStream::from_raw(std::ptr::null_mut()) };
         assert!(stream.as_raw().is_null());
     }
 
     #[test]
-    fn test_arrow_schema_from_raw() {
-        let null_ptr = std::ptr::null_mut();
-        let schema = unsafe { ArrowSchema::from_raw(null_ptr) };
+    fn arrow_schema_from_raw_accepts_null() {
+        let schema = unsafe { ArrowSchema::from_raw(std::ptr::null_mut()) };
         assert!(schema.as_raw().is_null());
     }
 
     #[test]
-    fn test_arrow_array_from_raw() {
-        let null_ptr = std::ptr::null_mut();
-        let array = unsafe { ArrowArray::from_raw(null_ptr) };
+    fn arrow_array_from_raw_accepts_null() {
+        let array = unsafe { ArrowArray::from_raw(std::ptr::null_mut()) };
         assert!(array.as_raw().is_null());
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -4,6 +4,8 @@
 
 use std::ffi::{c_char, CString};
 
+#[cfg(direct_arrow_insert)]
+use crate::arrow_options::InsertOptions;
 use crate::arrow_stream::{ArrowArray, ArrowSchema, ArrowStream};
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
@@ -193,34 +195,29 @@ impl Connection {
         result.check_error()
     }
 
-    /// Register an Arrow stream as a table function with the given name.
+    /// Register an Arrow C Data Interface stream for use with `ArrowStream('name')`.
     ///
-    /// This function registers an Arrow stream as a virtual table that can be queried
-    /// using SQL. The table will be available for queries until it is unregistered.
+    /// Pass a raw `ArrowArrayStream*` (see [`ArrowStream`](crate::arrow_stream::ArrowStream)).
+    /// Registered names are **not** ordinary tables; query them with the
+    /// [`arrow_stream_table_sql`](crate::arrow_stream::arrow_stream_table_sql) helper, e.g.
+    /// `SELECT * FROM ArrowStream('my_data')`.
     ///
-    /// # Arguments
-    ///
-    /// * `table_name` - The name to register for the Arrow stream table function
-    /// * `arrow_stream` - The Arrow stream handle to register
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(())` on success, or an [`Error`] if registration fails.
+    /// The stream pointer must stay valid until [`unregister_arrow_table`](Self::unregister_arrow_table)
+    /// is called or the connection is dropped.
     ///
     /// # Examples
     ///
     /// ```no_run
+    /// use chdb_rust::arrow_stream::{arrow_stream_table_sql, ArrowStream};
     /// use chdb_rust::connection::Connection;
-    /// use chdb_rust::arrow_stream::ArrowStream;
+    /// use chdb_rust::format::OutputFormat;
     ///
     /// let conn = Connection::open_in_memory()?;
-    ///
-    /// // Assuming you have an Arrow stream handle
-    /// // let arrow_stream = ArrowStream::from_raw(stream_ptr);
+    /// // let stream_ptr: *mut arrow::ffi::FFI_ArrowArrayStream = ...;
+    /// // let arrow_stream = unsafe { ArrowStream::from_raw(stream_ptr) };
     /// // conn.register_arrow_stream("my_data", &arrow_stream)?;
-    ///
-    /// // Now you can query it
-    /// // let result = conn.query("SELECT * FROM my_data", OutputFormat::JSONEachRow)?;
+    /// // let sql = format!("SELECT * FROM {}", arrow_stream_table_sql("my_data"));
+    /// // let _ = conn.query(&sql, OutputFormat::JSONEachRow)?;
     /// # Ok::<(), chdb_rust::error::Error>(())
     /// ```
     ///
@@ -252,15 +249,14 @@ impl Connection {
         }
     }
 
-    /// Register an Arrow array as a table function with the given name.
+    /// Register Arrow C Data Interface schema + array for use with `ArrowStream('name')`.
     ///
-    /// This function registers an Arrow array (with its schema) as a virtual table
-    /// that can be queried using SQL. The table will be available for queries until
-    /// it is unregistered.
+    /// libchdb wraps the pair in a one-shot stream. Query via
+    /// [`arrow_stream_table_sql`](crate::arrow_stream::arrow_stream_table_sql).
     ///
     /// # Arguments
     ///
-    /// * `table_name` - The name to register for the Arrow array table function
+    /// * `table_name` - The name to register for the Arrow stream table function
     /// * `arrow_schema` - The Arrow schema handle describing the array structure
     /// * `arrow_array` - The Arrow array handle containing the data
     ///
@@ -271,18 +267,20 @@ impl Connection {
     /// # Examples
     ///
     /// ```no_run
+    /// use chdb_rust::arrow_stream::{arrow_stream_table_sql, ArrowArray, ArrowSchema};
     /// use chdb_rust::connection::Connection;
-    /// use chdb_rust::arrow_stream::{ArrowSchema, ArrowArray};
+    /// use chdb_rust::format::OutputFormat;
     ///
     /// let conn = Connection::open_in_memory()?;
     ///
-    /// // Assuming you have Arrow schema and array handles
-    /// // let arrow_schema = ArrowSchema::from_raw(schema_ptr);
-    /// // let arrow_array = ArrowArray::from_raw(array_ptr);
+    /// // Assuming you have Arrow C Data Interface schema and array handles
+    /// // let arrow_schema = unsafe { ArrowSchema::from_raw(schema_ptr) };
+    /// // let arrow_array = unsafe { ArrowArray::from_raw(array_ptr) };
     /// // conn.register_arrow_array("my_data", &arrow_schema, &arrow_array)?;
     ///
-    /// // Now you can query it
-    /// // let result = conn.query("SELECT * FROM my_data", OutputFormat::JSONEachRow)?;
+    /// // Query via the ArrowStream table function
+    /// // let sql = format!("SELECT * FROM {}", arrow_stream_table_sql("my_data"));
+    /// // let result = conn.query(&sql, OutputFormat::JSONEachRow)?;
     /// # Ok::<(), chdb_rust::error::Error>(())
     /// ```
     ///
@@ -374,6 +372,87 @@ impl Connection {
             )))
         }
     }
+
+    /// Insert rows from a registered Arrow schema+array directly into `dest_table`.
+    ///
+    /// Requires libchdb built with `chdb_insert_arrow_array` (see `direct_arrow_insert` cfg).
+    #[cfg(direct_arrow_insert)]
+    pub fn insert_arrow_array(
+        &self,
+        dest_table: &str,
+        arrow_schema: &ArrowSchema,
+        arrow_array: &ArrowArray,
+        options: &InsertOptions,
+    ) -> Result<()> {
+        let dest_cstr = CString::new(dest_table)?;
+        let (options_ptr, _settings) = build_insert_options_c(options)?;
+
+        let conn = unsafe { *self.inner };
+        let result_ptr = unsafe {
+            bindings::chdb_insert_arrow_array(
+                conn,
+                dest_cstr.as_ptr(),
+                arrow_schema.as_raw(),
+                arrow_array.as_raw(),
+                options_ptr,
+            )
+        };
+
+        check_insert_result(result_ptr)
+    }
+
+    /// Insert rows from a registered Arrow stream directly into `dest_table`.
+    ///
+    /// Requires libchdb built with `chdb_insert_arrow_stream` (see `direct_arrow_insert` cfg).
+    #[cfg(direct_arrow_insert)]
+    pub fn insert_arrow_stream(
+        &self,
+        dest_table: &str,
+        arrow_stream: &ArrowStream,
+        options: &InsertOptions,
+    ) -> Result<()> {
+        let dest_cstr = CString::new(dest_table)?;
+        let (options_ptr, _settings) = build_insert_options_c(options)?;
+
+        let conn = unsafe { *self.inner };
+        let result_ptr = unsafe {
+            bindings::chdb_insert_arrow_stream(
+                conn,
+                dest_cstr.as_ptr(),
+                arrow_stream.as_raw(),
+                options_ptr,
+            )
+        };
+
+        check_insert_result(result_ptr)
+    }
+}
+
+#[cfg(direct_arrow_insert)]
+fn build_insert_options_c(
+    options: &InsertOptions,
+) -> Result<(*const bindings::chdb_arrow_insert_options, Option<CString>)> {
+    let settings_cstr = options.settings_clause().map(CString::new).transpose()?;
+    let c_options = settings_cstr
+        .as_ref()
+        .map(|settings| bindings::chdb_arrow_insert_options {
+            settings: settings.as_ptr(),
+        });
+    let options_ptr = c_options
+        .as_ref()
+        .map(|opts| opts as *const bindings::chdb_arrow_insert_options)
+        .unwrap_or(std::ptr::null());
+    Ok((options_ptr, settings_cstr))
+}
+
+#[cfg(direct_arrow_insert)]
+fn check_insert_result(result_ptr: *mut bindings::chdb_result) -> Result<()> {
+    if result_ptr.is_null() {
+        return Err(Error::NoResult);
+    }
+
+    let result = QueryResult::new(result_ptr);
+    result.check_error().map(|_| ())
 }
 
 impl Drop for Connection {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -4,8 +4,9 @@
 
 use std::ffi::{c_char, CString};
 
-#[cfg(direct_arrow_insert)]
+#[cfg(all(feature = "arrow", direct_arrow_insert))]
 use crate::arrow_options::InsertOptions;
+#[cfg(feature = "arrow")]
 use crate::arrow_stream::{ArrowArray, ArrowSchema, ArrowStream};
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
@@ -196,6 +197,7 @@ impl Connection {
     }
 
     /// Register an Arrow C Data Interface stream for use with `ArrowStream('name')`.
+    #[cfg(feature = "arrow")]
     ///
     /// Pass a raw `ArrowArrayStream*` (see [`ArrowStream`](crate::arrow_stream::ArrowStream)).
     /// Registered names are **not** ordinary tables; query them with the
@@ -250,6 +252,7 @@ impl Connection {
     }
 
     /// Register Arrow C Data Interface schema + array for use with `ArrowStream('name')`.
+    #[cfg(feature = "arrow")]
     ///
     /// libchdb wraps the pair in a one-shot stream. Query via
     /// [`arrow_stream_table_sql`](crate::arrow_stream::arrow_stream_table_sql).
@@ -319,6 +322,7 @@ impl Connection {
     }
 
     /// Unregister an Arrow stream table function that was previously registered.
+    #[cfg(feature = "arrow")]
     ///
     /// This function removes a previously registered Arrow stream table function,
     /// making it no longer available for queries.
@@ -376,7 +380,7 @@ impl Connection {
     /// Insert rows from a registered Arrow schema+array directly into `dest_table`.
     ///
     /// Requires libchdb built with `chdb_insert_arrow_array` (see `direct_arrow_insert` cfg).
-    #[cfg(direct_arrow_insert)]
+    #[cfg(all(feature = "arrow", direct_arrow_insert))]
     pub fn insert_arrow_array(
         &self,
         dest_table: &str,
@@ -404,7 +408,7 @@ impl Connection {
     /// Insert rows from a registered Arrow stream directly into `dest_table`.
     ///
     /// Requires libchdb built with `chdb_insert_arrow_stream` (see `direct_arrow_insert` cfg).
-    #[cfg(direct_arrow_insert)]
+    #[cfg(all(feature = "arrow", direct_arrow_insert))]
     pub fn insert_arrow_stream(
         &self,
         dest_table: &str,
@@ -428,7 +432,7 @@ impl Connection {
     }
 }
 
-#[cfg(direct_arrow_insert)]
+#[cfg(all(feature = "arrow", direct_arrow_insert))]
 fn build_insert_options_c(
     options: &InsertOptions,
 ) -> Result<(*const bindings::chdb_arrow_insert_options, Option<CString>)> {
@@ -445,7 +449,7 @@ fn build_insert_options_c(
     Ok((options_ptr, settings_cstr))
 }
 
-#[cfg(direct_arrow_insert)]
+#[cfg(all(feature = "arrow", direct_arrow_insert))]
 fn check_insert_result(result_ptr: *mut bindings::chdb_result) -> Result<()> {
     if result_ptr.is_null() {
         return Err(Error::NoResult);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! - **Stateless queries**: Execute one-off queries without persistent storage
 //! - **Stateful sessions**: Create databases and tables with persistent storage
 //! - **Multiple output formats**: JSON, CSV, TabSeparated, and more
+//! - **Arrow bulk insert**: [`insert_record_batch`](arrow_insert::insert_record_batch) via `ArrowStream('name')`
 //! - **Thread-safe**: Connections and results can be safely sent between threads
 //!
 //! ## Examples
@@ -37,7 +38,15 @@
 //! All public functions are safe to call, and the crate ensures proper resource cleanup.
 
 pub mod arg;
+pub mod arrow_insert;
+pub mod arrow_options;
 pub mod arrow_stream;
+pub use arrow_insert::{
+    insert_record_batch, insert_record_batch_direct, insert_record_batch_reader,
+    insert_record_batches,
+};
+pub use arrow_options::InsertOptions;
+pub use arrow_stream::arrow_stream_table_sql;
 #[allow(
     dead_code,
     unused,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! - **Stateless queries**: Execute one-off queries without persistent storage
 //! - **Stateful sessions**: Create databases and tables with persistent storage
 //! - **Multiple output formats**: JSON, CSV, TabSeparated, and more
-//! - **Arrow bulk insert**: [`insert_record_batch`](arrow_insert::insert_record_batch) via `ArrowStream('name')`
+//! - **Arrow bulk insert** (feature `arrow`, on by default): [`insert_record_batch`](arrow_insert::insert_record_batch) via `ArrowStream('name')`. Use [`chdb_rust::arrow`](arrow) types so your Arrow version matches the crate.
 //! - **Thread-safe**: Connections and results can be safely sent between threads
 //!
 //! ## Examples
@@ -38,14 +38,22 @@
 //! All public functions are safe to call, and the crate ensures proper resource cleanup.
 
 pub mod arg;
+#[cfg(feature = "arrow")]
 pub mod arrow_insert;
+#[cfg(feature = "arrow")]
 pub mod arrow_options;
+#[cfg(feature = "arrow")]
 pub mod arrow_stream;
+#[cfg(feature = "arrow")]
+pub use arrow;
+#[cfg(feature = "arrow")]
 pub use arrow_insert::{
     insert_record_batch, insert_record_batch_direct, insert_record_batch_reader,
     insert_record_batches,
 };
+#[cfg(feature = "arrow")]
 pub use arrow_options::InsertOptions;
+#[cfg(feature = "arrow")]
 pub use arrow_stream::arrow_stream_table_sql;
 #[allow(
     dead_code,

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,14 +6,18 @@
 use std::path::PathBuf;
 use std::{fs, io};
 
+#[cfg(feature = "arrow")]
 use arrow::array::{RecordBatch, RecordBatchReader};
+#[cfg(feature = "arrow")]
 use arrow::datatypes::SchemaRef;
 
 use crate::arg::{extract_output_format, Arg};
+#[cfg(feature = "arrow")]
 use crate::arrow_insert::{
     insert_record_batch, insert_record_batch_direct, insert_record_batch_reader,
     insert_record_batches,
 };
+#[cfg(feature = "arrow")]
 use crate::arrow_options::InsertOptions;
 use crate::connection::Connection;
 use crate::error::{Error, Result};
@@ -347,6 +351,7 @@ impl Session {
     }
 
     /// See [`insert_record_batch`](crate::arrow_insert::insert_record_batch).
+    #[cfg(feature = "arrow")]
     pub fn insert_record_batch(
         &self,
         dest_table: &str,
@@ -358,6 +363,7 @@ impl Session {
     }
 
     /// See [`insert_record_batch_direct`](crate::arrow_insert::insert_record_batch_direct).
+    #[cfg(feature = "arrow")]
     pub fn insert_record_batch_direct(
         &self,
         dest_table: &str,
@@ -368,6 +374,7 @@ impl Session {
     }
 
     /// See [`insert_record_batches`](crate::arrow_insert::insert_record_batches).
+    #[cfg(feature = "arrow")]
     pub fn insert_record_batches(
         &self,
         dest_table: &str,
@@ -387,6 +394,7 @@ impl Session {
     }
 
     /// See [`insert_record_batch_reader`](crate::arrow_insert::insert_record_batch_reader).
+    #[cfg(feature = "arrow")]
     pub fn insert_record_batch_reader(
         &self,
         dest_table: &str,

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,15 @@
 use std::path::PathBuf;
 use std::{fs, io};
 
+use arrow::array::{RecordBatch, RecordBatchReader};
+use arrow::datatypes::SchemaRef;
+
 use crate::arg::{extract_output_format, Arg};
+use crate::arrow_insert::{
+    insert_record_batch, insert_record_batch_direct, insert_record_batch_reader,
+    insert_record_batches,
+};
+use crate::arrow_options::InsertOptions;
 use crate::connection::Connection;
 use crate::error::{Error, Result};
 use crate::format::OutputFormat;
@@ -331,6 +339,62 @@ impl Session {
     pub fn execute(&self, query: &str, query_args: Option<&[Arg]>) -> Result<QueryResult> {
         let fmt = extract_output_format(query_args, self.default_format);
         self.conn.query(query, fmt)
+    }
+
+    /// Access the session's [`Connection`] for Arrow registration and low-level queries.
+    pub fn connection(&self) -> &Connection {
+        &self.conn
+    }
+
+    /// See [`insert_record_batch`](crate::arrow_insert::insert_record_batch).
+    pub fn insert_record_batch(
+        &self,
+        dest_table: &str,
+        stream_name: &str,
+        batch: RecordBatch,
+        options: InsertOptions,
+    ) -> Result<()> {
+        insert_record_batch(self.connection(), dest_table, stream_name, batch, options)
+    }
+
+    /// See [`insert_record_batch_direct`](crate::arrow_insert::insert_record_batch_direct).
+    pub fn insert_record_batch_direct(
+        &self,
+        dest_table: &str,
+        batch: RecordBatch,
+        options: InsertOptions,
+    ) -> Result<()> {
+        insert_record_batch_direct(self.connection(), dest_table, batch, options)
+    }
+
+    /// See [`insert_record_batches`](crate::arrow_insert::insert_record_batches).
+    pub fn insert_record_batches(
+        &self,
+        dest_table: &str,
+        stream_name: &str,
+        schema: SchemaRef,
+        batches: Vec<RecordBatch>,
+        options: InsertOptions,
+    ) -> Result<()> {
+        insert_record_batches(
+            self.connection(),
+            dest_table,
+            stream_name,
+            schema,
+            batches,
+            options,
+        )
+    }
+
+    /// See [`insert_record_batch_reader`](crate::arrow_insert::insert_record_batch_reader).
+    pub fn insert_record_batch_reader(
+        &self,
+        dest_table: &str,
+        stream_name: &str,
+        reader: Box<dyn RecordBatchReader + Send>,
+        options: InsertOptions,
+    ) -> Result<()> {
+        insert_record_batch_reader(self.connection(), dest_table, stream_name, reader, options)
     }
 }
 

--- a/tests/arrow_insert.rs
+++ b/tests/arrow_insert.rs
@@ -1,0 +1,343 @@
+//! End-to-end Arrow bulk insert into MergeTree tables.
+
+use std::sync::Arc;
+
+use arrow::array::TimestampNanosecondArray;
+use arrow::array::{Float64Array, Int64Array, RecordBatch, StringArray, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use chdb_rust::arrow_insert::{
+    insert_record_batch, insert_record_batch_direct, insert_record_batches,
+};
+use chdb_rust::arrow_options::InsertOptions;
+use chdb_rust::connection::Connection;
+use chdb_rust::format::OutputFormat;
+use chdb_rust::session::SessionBuilder;
+
+fn bulk_opts() -> InsertOptions {
+    InsertOptions::default_bulk()
+}
+
+#[test]
+fn insert_record_batch_direct_writes_to_merge_tree() {
+    let conn = Connection::open_in_memory().expect("conn");
+    conn.query(
+        "CREATE TABLE direct_dest (id Int64) ENGINE=MergeTree ORDER BY id",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create");
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+        vec![Arc::new(Int64Array::from(vec![300i64, 400, 500]))],
+    )
+    .expect("batch");
+
+    insert_record_batch_direct(&conn, "direct_dest", batch, bulk_opts()).expect("insert");
+
+    let count = conn
+        .query(
+            "SELECT count() FROM direct_dest",
+            OutputFormat::TabSeparated,
+        )
+        .expect("count")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(count.trim(), "3");
+}
+
+#[test]
+fn insert_record_batch_helper_writes_to_merge_tree() {
+    let conn = Connection::open_in_memory().expect("conn");
+    conn.query(
+        "CREATE TABLE dest (id Int64) ENGINE=MergeTree ORDER BY id",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create");
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+        vec![Arc::new(Int64Array::from(vec![100i64, 200]))],
+    )
+    .expect("batch");
+
+    insert_record_batch(&conn, "dest", "helper_batch", batch, bulk_opts()).expect("insert");
+
+    let count = conn
+        .query("SELECT count() FROM dest", OutputFormat::TabSeparated)
+        .expect("count")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(count.trim(), "2");
+}
+
+#[test]
+fn insert_record_batches_writes_all_rows() {
+    let conn = Connection::open_in_memory().expect("conn");
+    conn.query(
+        "CREATE TABLE multi_dest (id Int64) ENGINE=MergeTree ORDER BY id",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create");
+
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    let batches = vec![
+        RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1i64, 2]))],
+        )
+        .expect("batch 1"),
+        RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![3i64, 4, 5]))],
+        )
+        .expect("batch 2"),
+    ];
+
+    insert_record_batches(
+        &conn,
+        "multi_dest",
+        "multi_stream",
+        schema,
+        batches,
+        bulk_opts(),
+    )
+    .expect("insert");
+
+    let count = conn
+        .query("SELECT count() FROM multi_dest", OutputFormat::TabSeparated)
+        .expect("count")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(count.trim(), "5");
+
+    let sum = conn
+        .query("SELECT sum(id) FROM multi_dest", OutputFormat::TabSeparated)
+        .expect("sum")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(sum.trim(), "15");
+}
+
+#[test]
+fn session_insert_record_batch_writes_to_merge_tree() {
+    let session = SessionBuilder::new()
+        .with_data_path(std::env::temp_dir().join("chdb-rust-session-insert-test"))
+        .with_auto_cleanup(true)
+        .build()
+        .expect("session");
+
+    session
+        .execute(
+            "CREATE TABLE session_dest (id Int64) ENGINE=MergeTree ORDER BY id",
+            None,
+        )
+        .expect("create");
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+        vec![Arc::new(Int64Array::from(vec![42i64, 43]))],
+    )
+    .expect("batch");
+
+    session
+        .insert_record_batch("session_dest", "session_stream", batch, bulk_opts())
+        .expect("insert");
+
+    let count = session
+        .execute("SELECT count() FROM session_dest", None)
+        .expect("count")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(count.trim(), "2");
+}
+
+/// The Arrow insert must map batch columns to destination columns by NAME, not
+/// by position. A positional mapping silently scatters values into the wrong
+/// columns whenever the table's physical column order differs from the batch's
+/// (e.g. after `ALTER TABLE ... ADD COLUMN`, which appends).
+#[test]
+fn arrow_insert_maps_columns_by_name_not_position() {
+    let conn = Connection::open_in_memory().expect("conn");
+    conn.query(
+        "CREATE TABLE t (a Int64, b Int64) ENGINE=Memory",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create");
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("b", DataType::Int64, false),
+            Field::new("a", DataType::Int64, false),
+        ])),
+        vec![
+            Arc::new(Int64Array::from(vec![2i64])),
+            Arc::new(Int64Array::from(vec![1i64])),
+        ],
+    )
+    .expect("batch");
+
+    insert_record_batch_direct(&conn, "t", batch, bulk_opts()).expect("insert");
+
+    let out = conn
+        .query("SELECT a, b FROM t", OutputFormat::TabSeparated)
+        .expect("select")
+        .data_utf8()
+        .expect("utf8")
+        .trim()
+        .to_string();
+
+    assert_eq!(
+        out, "1\t2",
+        "Arrow insert must map columns by name, not position"
+    );
+}
+
+/// ClickHouse MATERIALIZED VIEW fires on Arrow C Data Interface inserts.
+#[test]
+fn materialized_view_triggers_on_arrow_insert() {
+    let conn = Connection::open_in_memory().expect("conn");
+
+    conn.query(
+        "CREATE TABLE mv_source (
+            time DateTime64(9, 'UTC'),
+            origin_node_id UInt64,
+            ingest_seq UInt64,
+            series_id UInt64,
+            value Nullable(Float64)
+        ) ENGINE = ReplacingMergeTree(ingest_seq)
+        ORDER BY (series_id, time)",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create source");
+
+    conn.query(
+        "CREATE TABLE mv_dest (
+            time DateTime64(9, 'UTC'),
+            origin_node_id UInt64,
+            ingest_seq UInt64,
+            series_id UInt64,
+            value Nullable(Float64)
+        ) ENGINE = ReplacingMergeTree(ingest_seq)
+        ORDER BY (series_id, time)",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create dest");
+
+    conn.query(
+        "CREATE MATERIALIZED VIEW mv_fact TO mv_dest AS
+         SELECT
+            toStartOfInterval(time, INTERVAL 5 MINUTE) AS time,
+            any(origin_node_id) AS origin_node_id,
+            max(ingest_seq) AS ingest_seq,
+            series_id,
+            avg(value) AS value
+         FROM mv_source
+         GROUP BY series_id, time",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create fact mv");
+
+    conn.query(
+        "CREATE TABLE mv_source_series (
+            series_id UInt64,
+            host LowCardinality(String)
+        ) ENGINE = ReplacingMergeTree()
+        ORDER BY (series_id)",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create source series");
+
+    conn.query(
+        "CREATE TABLE mv_dest_series (
+            series_id UInt64,
+            host LowCardinality(String)
+        ) ENGINE = ReplacingMergeTree()
+        ORDER BY (series_id)",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create dest series");
+
+    conn.query(
+        "CREATE MATERIALIZED VIEW mv_series TO mv_dest_series AS
+         SELECT * FROM mv_source_series",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create series mv");
+
+    let fact_schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "time",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+            false,
+        ),
+        Field::new("origin_node_id", DataType::UInt64, false),
+        Field::new("ingest_seq", DataType::UInt64, false),
+        Field::new("series_id", DataType::UInt64, false),
+        Field::new("value", DataType::Float64, true),
+    ]));
+
+    let ts: i64 = 1_700_000_000_000_000_000;
+    let fact_batch = RecordBatch::try_new(
+        Arc::clone(&fact_schema),
+        vec![
+            Arc::new(
+                TimestampNanosecondArray::from(vec![ts, ts + 60_000_000_000]).with_timezone("UTC"),
+            ),
+            Arc::new(UInt64Array::from(vec![1u64, 1])),
+            Arc::new(UInt64Array::from(vec![1u64, 2])),
+            Arc::new(UInt64Array::from(vec![100u64, 100])),
+            Arc::new(Float64Array::from(vec![Some(10.0), Some(20.0)])),
+        ],
+    )
+    .expect("fact batch");
+
+    insert_record_batch_direct(&conn, "mv_source", fact_batch, bulk_opts()).expect("fact insert");
+
+    let series_schema = Arc::new(Schema::new(vec![
+        Field::new("series_id", DataType::UInt64, false),
+        Field::new("host", DataType::Utf8, false),
+    ]));
+    let series_batch = RecordBatch::try_new(
+        series_schema,
+        vec![
+            Arc::new(UInt64Array::from(vec![100u64])),
+            Arc::new(StringArray::from(vec!["h1"])),
+        ],
+    )
+    .expect("series batch");
+
+    insert_record_batch_direct(&conn, "mv_source_series", series_batch, bulk_opts())
+        .expect("series insert");
+
+    let dest_count = conn
+        .query("SELECT count() FROM mv_dest", OutputFormat::TabSeparated)
+        .expect("dest count")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(
+        dest_count.trim(),
+        "1",
+        "aggregating MV should produce one 5m bucket from two source rows"
+    );
+
+    let dest_avg = conn
+        .query("SELECT value FROM mv_dest", OutputFormat::TabSeparated)
+        .expect("dest avg")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(dest_avg.trim(), "15", "expected avg(10, 20) = 15 in dest");
+
+    let series_count = conn
+        .query(
+            "SELECT count() FROM mv_dest_series",
+            OutputFormat::TabSeparated,
+        )
+        .expect("series count")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(
+        series_count.trim(),
+        "1",
+        "passthrough series MV should copy dimension row"
+    );
+}

--- a/tests/arrow_insert_bench.rs
+++ b/tests/arrow_insert_bench.rs
@@ -1,0 +1,200 @@
+//! Compare insert paths on identical row counts (manual / release bench).
+//!
+//! ```text
+//! LD_LIBRARY_PATH=. cargo test --release --test arrow_insert_bench -- --ignored --nocapture --test-threads=1
+//! ```
+
+use std::io::Write as _;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow::array::{
+    Float64Array, Int64Array, RecordBatch, StringArray, TimestampNanosecondArray, UInt64Array,
+};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::ipc::writer::StreamWriter;
+use chdb_rust::arrow_insert::insert_record_batch;
+use chdb_rust::arrow_options::InsertOptions;
+use chdb_rust::connection::Connection;
+use chdb_rust::format::OutputFormat;
+use tempfile::NamedTempFile;
+
+const ROWS: i64 = 50_000;
+
+fn bulk_opts() -> InsertOptions {
+    InsertOptions::default_bulk()
+}
+
+fn make_batch() -> RecordBatch {
+    let ids: Vec<i64> = (0..ROWS).collect();
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+        vec![Arc::new(Int64Array::from(ids))],
+    )
+    .expect("batch")
+}
+
+/// Wide telemetry schema for conversion-cost benchmarking.
+fn make_wide_batch() -> RecordBatch {
+    let n = ROWS as usize;
+    let times: Vec<i64> = (0..n as i64).map(|i| i * 1_000_000).collect();
+    let origins = vec![1u64; n];
+    let seqs: Vec<u64> = (0..n as u64).collect();
+    let sids: Vec<u64> = (0..n as u64).map(|i| i % 100).collect();
+    let values: Vec<f64> = (0..n as i64).map(|i| i as f64 * 0.5).collect();
+    let tags: Vec<&str> = (0..n)
+        .map(|i| if i % 2 == 0 { "host-a" } else { "host-b" })
+        .collect();
+
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new(
+                "time",
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                false,
+            ),
+            Field::new("origin_node_id", DataType::UInt64, false),
+            Field::new("ingest_seq", DataType::UInt64, false),
+            Field::new("series_id", DataType::UInt64, false),
+            Field::new("value", DataType::Float64, true),
+            Field::new("host", DataType::Utf8, true),
+        ])),
+        vec![
+            Arc::new(TimestampNanosecondArray::from(times).with_timezone("UTC")),
+            Arc::new(UInt64Array::from(origins)),
+            Arc::new(UInt64Array::from(seqs)),
+            Arc::new(UInt64Array::from(sids)),
+            Arc::new(Float64Array::from(values)),
+            Arc::new(StringArray::from(tags)),
+        ],
+    )
+    .expect("wide batch")
+}
+
+fn setup_table(conn: &Connection) {
+    conn.query("DROP TABLE IF EXISTS bench_t", OutputFormat::TabSeparated)
+        .ok();
+    conn.query(
+        "CREATE TABLE bench_t (id Int64) ENGINE=MergeTree ORDER BY id",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create");
+}
+
+fn setup_wide_table(conn: &Connection) {
+    conn.query(
+        "DROP TABLE IF EXISTS bench_wide",
+        OutputFormat::TabSeparated,
+    )
+    .ok();
+    conn.query(
+        "CREATE TABLE bench_wide (
+            time DateTime64(9, 'UTC'),
+            origin_node_id UInt64,
+            ingest_seq UInt64,
+            series_id UInt64,
+            value Nullable(Float64),
+            host Nullable(String)
+        ) ENGINE=MergeTree ORDER BY time",
+        OutputFormat::TabSeparated,
+    )
+    .expect("create wide");
+}
+
+fn count_rows(conn: &Connection) -> i64 {
+    conn.query("SELECT count() FROM bench_t", OutputFormat::TabSeparated)
+        .expect("count")
+        .data_utf8()
+        .expect("utf8")
+        .trim()
+        .parse()
+        .expect("parse count")
+}
+
+fn count_wide_rows(conn: &Connection) -> i64 {
+    conn.query("SELECT count() FROM bench_wide", OutputFormat::TabSeparated)
+        .expect("count")
+        .data_utf8()
+        .expect("utf8")
+        .trim()
+        .parse()
+        .expect("parse count")
+}
+
+#[test]
+#[ignore = "manual ingest benchmark; run with --release --ignored"]
+fn bench_insert_values() {
+    let conn = Connection::open_in_memory().expect("conn");
+    setup_table(&conn);
+
+    let start = Instant::now();
+    let sql = format!("INSERT INTO bench_t SELECT number AS id FROM numbers({ROWS})");
+    conn.query(&sql, OutputFormat::TabSeparated)
+        .expect("insert");
+    let elapsed = start.elapsed();
+
+    assert_eq!(count_rows(&conn), ROWS);
+    eprintln!("INSERT SELECT numbers({ROWS}): {elapsed:?}");
+}
+
+#[test]
+#[ignore = "manual ingest benchmark; run with --release --ignored"]
+fn bench_insert_arrowstream_file() {
+    let conn = Connection::open_in_memory().expect("conn");
+    setup_table(&conn);
+    let batch = make_batch();
+
+    let temp = NamedTempFile::new().expect("temp");
+    {
+        let mut writer = StreamWriter::try_new(temp.as_file(), &batch.schema()).expect("writer");
+        writer.write(&batch).expect("write");
+        writer.finish().expect("finish");
+        temp.as_file().flush().expect("flush");
+    }
+    let path = temp.path().display().to_string().replace('\\', "\\\\");
+
+    let start = Instant::now();
+    let sql = format!("INSERT INTO bench_t SELECT * FROM file('{path}', 'ArrowStream')");
+    conn.query(&sql, OutputFormat::TabSeparated)
+        .expect("insert");
+    let elapsed = start.elapsed();
+
+    assert_eq!(count_rows(&conn), ROWS);
+    eprintln!("INSERT via file(ArrowStream) {ROWS} rows: {elapsed:?}");
+}
+
+#[test]
+#[ignore = "manual ingest benchmark; run with --release --ignored"]
+fn bench_insert_register_arrow() {
+    let conn = Connection::open_in_memory().expect("conn");
+    setup_table(&conn);
+    let batch = make_batch();
+
+    let start = Instant::now();
+    insert_record_batch(&conn, "bench_t", "bench_reg", batch, bulk_opts()).expect("insert");
+    let elapsed = start.elapsed();
+
+    assert_eq!(count_rows(&conn), ROWS);
+    eprintln!("insert_record_batch (register_arrow_array) {ROWS} rows: {elapsed:?}");
+}
+
+#[test]
+#[ignore = "manual ingest benchmark; run with --release --ignored"]
+fn bench_insert_wide_schema_with_settings() {
+    let conn = Connection::open_in_memory().expect("conn");
+    setup_wide_table(&conn);
+    let batch = make_wide_batch();
+
+    let opts = InsertOptions {
+        max_threads: Some(4),
+        max_insert_block_size: Some(1_048_576),
+        min_insert_block_size_rows: Some(65_536),
+    };
+
+    let start = Instant::now();
+    insert_record_batch(&conn, "bench_wide", "bench_wide_reg", batch, opts).expect("insert");
+    let elapsed = start.elapsed();
+
+    assert_eq!(count_wide_rows(&conn), ROWS);
+    eprintln!("insert_record_batch wide schema {ROWS} rows: {elapsed:?}");
+}

--- a/tests/arrow_stream.rs
+++ b/tests/arrow_stream.rs
@@ -11,8 +11,7 @@ use chdb_rust::error::Error;
 #[test]
 fn test_arrow_stream_wrapper() {
     // Test creating ArrowStream from null pointer
-    let null_ptr = std::ptr::null_mut();
-    let stream = unsafe { ArrowStream::from_raw(null_ptr) };
+    let stream = unsafe { ArrowStream::from_raw(std::ptr::null_mut()) };
     assert!(stream.as_raw().is_null());
 
     // Test that we can clone and copy
@@ -140,8 +139,7 @@ fn test_unregister_nonexistent_table() {
 fn test_arrow_stream_send() {
     // Test that ArrowStream implements Send
     use std::thread;
-    let null_ptr = std::ptr::null_mut();
-    let stream = unsafe { ArrowStream::from_raw(null_ptr) };
+    let stream = unsafe { ArrowStream::from_raw(std::ptr::null_mut()) };
 
     thread::spawn(move || {
         let _ = stream;

--- a/tests/arrow_stream_roundtrip.rs
+++ b/tests/arrow_stream_roundtrip.rs
@@ -1,0 +1,113 @@
+//! End-to-end: register Arrow C Data Interface arrays and query via ArrowStream().
+
+use std::sync::Arc;
+
+use arrow::array::RecordBatchIterator;
+use arrow::array::{Int64Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::ffi::to_ffi;
+use arrow::ffi_stream::FFI_ArrowArrayStream;
+use chdb_rust::arrow_stream::{arrow_stream_table_sql, ArrowArray, ArrowSchema, ArrowStream};
+use chdb_rust::connection::Connection;
+use chdb_rust::format::OutputFormat;
+
+#[test]
+fn registered_arrow_array_is_queryable_via_arrow_stream_table_function() {
+    let conn = Connection::open_in_memory().expect("conn");
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+        vec![Arc::new(Int64Array::from(vec![10i64, 20, 30]))],
+    )
+    .expect("batch");
+
+    // Keep source data alive while FFI structs are registered.
+    let struct_array = arrow::array::StructArray::from(batch);
+    let (mut ffi_array, mut ffi_schema) = to_ffi(&struct_array.into()).expect("to_ffi");
+
+    let arrow_schema = unsafe { ArrowSchema::from_raw(&mut ffi_schema) };
+    let arrow_array = unsafe { ArrowArray::from_raw(&mut ffi_array) };
+
+    conn.register_arrow_array("probe_batch", &arrow_schema, &arrow_array)
+        .expect("register");
+
+    let sql = format!(
+        "SELECT sum(id) AS s FROM {}",
+        arrow_stream_table_sql("probe_batch")
+    );
+    let result = conn
+        .query(&sql, OutputFormat::TabSeparated)
+        .expect("query registered stream");
+
+    assert_eq!(
+        result.data_utf8().expect("utf8").trim(),
+        "60",
+        "expected sum(id)=60 from registered Arrow stream"
+    );
+
+    conn.unregister_arrow_table("probe_batch")
+        .expect("unregister");
+}
+
+#[test]
+fn registered_arrow_c_stream_is_queryable() {
+    let conn = Connection::open_in_memory().expect("conn");
+
+    let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int64, false)]));
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int64Array::from(vec![7i64, 8]))],
+    )
+    .expect("batch");
+
+    let reader = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema);
+    let mut ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
+
+    let arrow_stream = unsafe { ArrowStream::from_raw(&mut ffi_stream) };
+    conn.register_arrow_stream("stream_probe", &arrow_stream)
+        .expect("register stream");
+
+    let sql = format!(
+        "SELECT count() FROM {}",
+        arrow_stream_table_sql("stream_probe")
+    );
+    let count = conn
+        .query(&sql, OutputFormat::TabSeparated)
+        .expect("query stream")
+        .data_utf8()
+        .expect("utf8");
+    assert_eq!(count.trim(), "2");
+
+    conn.unregister_arrow_table("stream_probe")
+        .expect("unregister");
+}
+
+#[test]
+fn bare_table_name_still_unknown_for_registered_stream() {
+    let conn = Connection::open_in_memory().expect("conn");
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+        vec![Arc::new(Int64Array::from(vec![1i64]))],
+    )
+    .expect("batch");
+
+    let struct_array = arrow::array::StructArray::from(batch);
+    let (mut ffi_array, mut ffi_schema) = to_ffi(&struct_array.into()).expect("to_ffi");
+
+    let arrow_schema = unsafe { ArrowSchema::from_raw(&mut ffi_schema) };
+    let arrow_array = unsafe { ArrowArray::from_raw(&mut ffi_array) };
+
+    conn.register_arrow_array("bare_name_test", &arrow_schema, &arrow_array)
+        .expect("register");
+
+    let err = conn
+        .query("SELECT * FROM bare_name_test", OutputFormat::TabSeparated)
+        .expect_err("bare identifier must not resolve");
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("UNKNOWN_TABLE") || msg.contains("Unknown table"),
+        "expected UNKNOWN_TABLE for bare name, got: {msg}"
+    );
+}


### PR DESCRIPTION
Add high-throughput Arrow ingest for RecordBatch and RecordBatchReader, with automatic fallback between direct libchdb FFI (chdb_insert_arrow_*) and a register → INSERT … SELECT FROM ArrowStream('name') → unregister SQL path when the symbols are absent at link time.

Breaking change: ArrowStream, ArrowSchema, and ArrowArray now wrap Arrow C Data Interface pointers (FFI_ArrowArrayStream/Schema/Array). Registered names must be queried via ArrowStream('name'), not as bare table identifiers. Add arrow_stream_table_sql() to build the correct table expression.

Also includes named column lists on the SQL insert path (maps by column name, not position), InsertOptions tuning, session helpers, example 08, integration tests, and docs. Bumps crate version to 1.4.0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Arrow RecordBatch bulk insert to `Session` via C Data Interface
> - Adds `insert_record_batch`, `insert_record_batches`, and `insert_record_batch_reader` methods to `Session` and `Connection`, using Arrow's FFI (C Data Interface) to insert in-memory Arrow data into chDB tables without writing to disk.
> - Two insert paths are supported: a registration-based SQL path using the `ArrowStream('name')` table function (always available), and a direct FFI path via `chdb_insert_arrow_array`/`chdb_insert_arrow_stream` (enabled when the detected `libchdb` exports these symbols, gated by `cfg(direct_arrow_insert)`).
> - Adds `InsertOptions` in [src/arrow_options.rs](https://github.com/chdb-io/chdb-rust/pull/31/files#diff-db30e4986bb206d06d131be7273d4f0c3f7ef646adc0d3435a983903de668a8a) to configure ClickHouse insert settings (e.g. `max_threads`, `max_insert_block_size`) passed as a SQL `SETTINGS` clause or direct FFI options.
> - The `arrow` feature is enabled by default (pulling in Arrow 59), so downstream crates that set `default-features = false` will lose Arrow support.
> - Behavioral Change: package version bumps from 1.3.1 to 1.4.0 and the `arrow` crate becomes a default dependency, increasing compile times and binary size for all users who do not opt out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee60642.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->